### PR TITLE
Use git-auto-commit-action for reliable push from Actions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -41,10 +41,9 @@ jobs:
           python pipeline/update.py --output public/data $MANUAL
 
       - name: Commit and push (triggers Vercel redeploy)
-        run: |
-          git config user.name "F1 Bot"
-          git config user.email "bot@f1xpts.dev"
-          git add public/data/
-          git diff --staged --quiet || git commit -m "Update: $(date -u +%Y-%m-%d) race projections"
-          git pull --rebase origin master
-          git push origin master
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Update: race projections"
+          file_pattern: "public/data/**"
+          commit_user_name: "F1 Bot"
+          commit_user_email: "bot@f1xpts.dev"


### PR DESCRIPTION
## Summary
- Manual `git push` from Actions keeps failing with "rejected: fetch first" due to stale refs
- Replace manual git commands with `stefanzweifel/git-auto-commit-action@v5`, which is purpose-built for committing from GitHub Actions and handles all fetch/rebase/push edge cases

## Test plan
- [ ] Merge, then re-run the workflow
- [ ] Verify the commit and push step succeeds

https://claude.ai/code/session_01Gnqp86tVuMPyWf4XzRmiDB