### PR TITLE
Remove Dashboard button from nav

### DIFF
--- a/site/src/components/Nav.jsx
+++ b/site/src/components/Nav.jsx
@@ -23,12 +23,6 @@ export default function Nav({ page, setPage, race, races, selectedRace, onRaceCh
       </div>
       <div className="nav-links">
         <button
-          className={`nav-link ${page === 'dashboard' ? 'active' : ''}`}
-          onClick={() => setPage('dashboard')}
-        >
-          Dashboard
-        </button>
-        <button
           className={`nav-link ${page === 'methodology' ? 'active' : ''}`}
           onClick={() => setPage('methodology')}
         >


### PR DESCRIPTION
The race selector already navigates to the dashboard, making a
dedicated Dashboard button redundant.

https://claude.ai/code/session_01H8uA1oWacKYSb9qr8d7uiF