### PR TITLE
Fix race selection nav: make single race clickable and add Dashboard link

### DIFF
--- a/site/src/components/Nav.jsx
+++ b/site/src/components/Nav.jsx
@@ -26,12 +26,6 @@ export default function Nav({ page, setPage, race, races, selectedRace, onRaceCh
       </div>
       <div className="nav-links">
         <button
-          className={`nav-link ${page === 'dashboard' ? 'active' : ''}`}
-          onClick={() => setPage('dashboard')}
-        >
-          Dashboard
-        </button>
-        <button
           className={`nav-link ${page === 'methodology' ? 'active' : ''}`}
           onClick={() => setPage('methodology')}
         >

--- a/site/src/components/Nav.jsx
+++ b/site/src/components/Nav.jsx
@@ -9,7 +9,10 @@ export default function Nav({ page, setPage, race, races, selectedRace, onRaceCh
           <select
             className="nav-race-select"
             value={selectedRace || ''}
-            onChange={e => onRaceChange(e.target.value)}
+            onChange={e => {
+              onRaceChange(e.target.value);
+              setPage('dashboard');
+            }}
           >
             {races.map(r => (
               <option key={r.slug} value={r.slug}>
@@ -18,10 +21,16 @@ export default function Nav({ page, setPage, race, races, selectedRace, onRaceCh
             ))}
           </select>
         ) : (
-          <span className="nav-race">{race}</span>
+          <button className="nav-race nav-link" onClick={() => setPage('dashboard')}>{race}</button>
         )}
       </div>
       <div className="nav-links">
+        <button
+          className={`nav-link ${page === 'dashboard' ? 'active' : ''}`}
+          onClick={() => setPage('dashboard')}
+        >
+          Dashboard
+        </button>
         <button
           className={`nav-link ${page === 'methodology' ? 'active' : ''}`}
           onClick={() => setPage('methodology')}


### PR DESCRIPTION
When only one race exists, the race name was a plain span with no click handler,
making it impossible to navigate to the dashboard. Changed it to a clickable
button and added a Dashboard link to the nav links.

https://claude.ai/code/session_01Wry6QZG6MQRCCzU1PCVD6D