### PR TITLE
Add test suites for pipeline and client-side simulation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install numpy scipy requests pytest
+      - run: python -m pytest pipeline/tests/ -v
+  js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: cd site && npm ci && npm test

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -1,0 +1,112 @@
+"""Tests for config.py — grid consistency and scoring tables."""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from config import (
+    DRIVERS, TEAMS, N_DRIVERS, N_TEAMS,
+    RACE_POINTS, SPRINT_POINTS, DNF_PENALTY,
+    DRIVER_NAME_MAP, SPRINT_WEEKENDS, CALENDAR,
+)
+
+
+class TestGrid:
+    def test_22_drivers(self):
+        assert N_DRIVERS == 22
+
+    def test_11_teams(self):
+        assert N_TEAMS == 11
+
+    def test_drivers_match_n(self):
+        assert len(DRIVERS) == N_DRIVERS
+
+    def test_teams_match_n(self):
+        assert len(TEAMS) == N_TEAMS
+
+    def test_each_team_has_two_drivers(self):
+        from collections import Counter
+        team_counts = Counter(d["team_idx"] for d in DRIVERS)
+        for t in range(N_TEAMS):
+            assert team_counts[t] == 2, f"Team {TEAMS[t]['name']} has {team_counts[t]} drivers"
+
+    def test_team_indices_valid(self):
+        for d in DRIVERS:
+            assert 0 <= d["team_idx"] < N_TEAMS
+
+    def test_unique_abbreviations(self):
+        abbrs = [d["abbr"] for d in DRIVERS]
+        assert len(abbrs) == len(set(abbrs))
+
+    def test_abbreviations_three_chars(self):
+        for d in DRIVERS:
+            assert len(d["abbr"]) == 3
+
+    def test_all_teams_have_colors(self):
+        for t in TEAMS:
+            assert t["color"].startswith("#")
+            assert len(t["color"]) == 7  # #RRGGBB
+
+
+class TestScoring:
+    def test_race_points_p1(self):
+        assert RACE_POINTS[1] == 25
+
+    def test_race_points_p10(self):
+        assert RACE_POINTS[10] == 1
+
+    def test_race_points_top10_only(self):
+        assert set(RACE_POINTS.keys()) == set(range(1, 11))
+
+    def test_sprint_points_p1(self):
+        assert SPRINT_POINTS[1] == 8
+
+    def test_sprint_points_p8(self):
+        assert SPRINT_POINTS[8] == 1
+
+    def test_sprint_points_top8_only(self):
+        assert set(SPRINT_POINTS.keys()) == set(range(1, 9))
+
+    def test_race_points_decreasing(self):
+        for i in range(1, 10):
+            assert RACE_POINTS[i] > RACE_POINTS[i + 1]
+
+    def test_sprint_points_decreasing(self):
+        for i in range(1, 8):
+            assert SPRINT_POINTS[i] > SPRINT_POINTS[i + 1]
+
+    def test_dnf_penalty_negative(self):
+        assert DNF_PENALTY < 0
+
+
+class TestDriverNameMap:
+    def test_full_name_matches(self):
+        assert DRIVER_NAME_MAP["george russell"] == 0
+
+    def test_last_name_matches(self):
+        assert DRIVER_NAME_MAP["russell"] == 0
+
+    def test_abbreviation_matches(self):
+        assert DRIVER_NAME_MAP["rus"] == 0
+
+    def test_hulkenberg_alias(self):
+        assert DRIVER_NAME_MAP["hulkenberg"] == DRIVER_NAME_MAP["hülkenberg"]
+
+    def test_all_drivers_have_entries(self):
+        for i, d in enumerate(DRIVERS):
+            assert d["name"].lower() in DRIVER_NAME_MAP
+            assert d["abbr"].lower() in DRIVER_NAME_MAP
+
+
+class TestCalendar:
+    def test_22_races(self):
+        assert len(CALENDAR) == 22
+
+    def test_rounds_sequential(self):
+        rounds = [r["round"] for r in CALENDAR]
+        assert rounds == list(range(1, 23))
+
+    def test_sprint_weekends_in_calendar(self):
+        slugs = {r["slug"] for r in CALENDAR}
+        for sw in SPRINT_WEEKENDS:
+            assert sw in slugs, f"Sprint weekend {sw} not in calendar"

--- a/pipeline/tests/test_devig.py
+++ b/pipeline/tests/test_devig.py
@@ -1,0 +1,203 @@
+"""Tests for devig.py — odds conversion and devigorization methods."""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pytest
+from devig import (
+    american_to_implied,
+    decimal_to_implied,
+    fractional_to_implied,
+    devig_multiplicative,
+    devig_shin,
+    devig_power,
+    devig_market,
+)
+
+
+# --- Odds conversion ---
+
+class TestAmericanToImplied:
+    def test_even_money(self):
+        assert american_to_implied(100) == pytest.approx(0.5)
+
+    def test_favorite(self):
+        # -200 means risk 200 to win 100 → implied = 200/300 = 0.6667
+        assert american_to_implied(-200) == pytest.approx(2 / 3)
+
+    def test_heavy_favorite(self):
+        assert american_to_implied(-500) == pytest.approx(5 / 6)
+
+    def test_underdog(self):
+        # +300 means risk 100 to win 300 → implied = 100/400 = 0.25
+        assert american_to_implied(300) == pytest.approx(0.25)
+
+    def test_longshot(self):
+        # +10000 → 100/10100 ≈ 0.0099
+        result = american_to_implied(10000)
+        assert 0.009 < result < 0.01
+
+    def test_implied_between_0_and_1(self):
+        for odds in [-500, -200, -100, 100, 200, 500, 5000]:
+            p = american_to_implied(odds)
+            assert 0 < p < 1
+
+
+class TestDecimalToImplied:
+    def test_even_money(self):
+        assert decimal_to_implied(2.0) == pytest.approx(0.5)
+
+    def test_favorite(self):
+        assert decimal_to_implied(1.5) == pytest.approx(2 / 3)
+
+    def test_longshot(self):
+        assert decimal_to_implied(10.0) == pytest.approx(0.1)
+
+
+class TestFractionalToImplied:
+    def test_even_money(self):
+        assert fractional_to_implied(1, 1) == pytest.approx(0.5)
+
+    def test_odds_on(self):
+        # 1/2 → den/(num+den) = 2/3
+        assert fractional_to_implied(1, 2) == pytest.approx(2 / 3)
+
+    def test_longshot(self):
+        # 10/1 → 1/11
+        assert fractional_to_implied(10, 1) == pytest.approx(1 / 11)
+
+
+# --- Devig methods ---
+
+@pytest.fixture
+def viggy_probs():
+    """Implied probabilities with ~10% overround (sum ≈ 1.10)."""
+    return np.array([0.40, 0.25, 0.20, 0.15, 0.10])
+
+
+@pytest.fixture
+def fair_field():
+    """A fair 22-driver field: implied probs sum to ~1.15 (typical vig)."""
+    rng = np.random.default_rng(42)
+    raw = rng.dirichlet(np.ones(22))  # fair probs
+    # Add ~15% vig
+    return raw * 1.15
+
+
+class TestDevigMultiplicative:
+    def test_sums_to_one(self, viggy_probs):
+        result = devig_multiplicative(viggy_probs)
+        assert result.sum() == pytest.approx(1.0)
+
+    def test_preserves_ranking(self, viggy_probs):
+        result = devig_multiplicative(viggy_probs)
+        # Largest implied → largest fair
+        assert np.argmax(result) == np.argmax(viggy_probs)
+
+    def test_all_positive(self, viggy_probs):
+        result = devig_multiplicative(viggy_probs)
+        assert (result > 0).all()
+
+    def test_zero_sum_raises(self):
+        with pytest.raises(ValueError):
+            devig_multiplicative(np.array([0.0, 0.0]))
+
+
+class TestDevigShin:
+    def test_sums_to_one(self, viggy_probs):
+        result = devig_shin(viggy_probs)
+        assert result.sum() == pytest.approx(1.0, abs=1e-6)
+
+    def test_preserves_ranking(self, viggy_probs):
+        result = devig_shin(viggy_probs)
+        order_implied = np.argsort(-viggy_probs)
+        order_fair = np.argsort(-result)
+        np.testing.assert_array_equal(order_implied, order_fair)
+
+    def test_all_positive(self, viggy_probs):
+        result = devig_shin(viggy_probs)
+        assert (result > 0).all()
+
+    def test_reduces_overround(self, viggy_probs):
+        result = devig_shin(viggy_probs)
+        # Fair probs should be smaller than implied (each individually)
+        assert (result <= viggy_probs).all()
+
+    def test_no_vig_passthrough(self):
+        """If probs already sum to 1, Shin should return them unchanged."""
+        fair = np.array([0.5, 0.3, 0.2])
+        result = devig_shin(fair)
+        np.testing.assert_allclose(result, fair, atol=1e-6)
+
+    def test_favorite_longshot_bias(self):
+        """Shin should remove more from longshots than favorites (FLB correction)."""
+        implied = np.array([0.60, 0.30, 0.10, 0.05, 0.05])  # sum=1.10
+        fair = devig_shin(implied)
+        mult = devig_multiplicative(implied)
+        # For the favorite, Shin's fair prob should be higher than multiplicative
+        # (FLB means favorites are underpriced, longshots overpriced)
+        assert fair[0] > mult[0]
+
+    def test_large_field(self, fair_field):
+        result = devig_shin(fair_field)
+        assert result.sum() == pytest.approx(1.0, abs=1e-6)
+        assert (result > 0).all()
+
+
+class TestDevigPower:
+    def test_sums_to_one(self, viggy_probs):
+        result = devig_power(viggy_probs)
+        assert result.sum() == pytest.approx(1.0, abs=1e-5)
+
+    def test_preserves_ranking(self, viggy_probs):
+        result = devig_power(viggy_probs)
+        order_implied = np.argsort(-viggy_probs)
+        order_fair = np.argsort(-result)
+        np.testing.assert_array_equal(order_implied, order_fair)
+
+    def test_all_positive(self, viggy_probs):
+        result = devig_power(viggy_probs)
+        assert (result > 0).all()
+
+
+# --- Market-level devig ---
+
+class TestDevigMarket:
+    @pytest.fixture
+    def win_odds(self):
+        return {
+            "Russell": -150,
+            "Antonelli": 200,
+            "Leclerc": 600,
+            "Verstappen": 1200,
+        }
+
+    def test_returns_dict(self, win_odds):
+        result = devig_market(win_odds, format="american", method="shin")
+        assert isinstance(result, dict)
+        assert set(result.keys()) == set(win_odds.keys())
+
+    def test_sums_to_one(self, win_odds):
+        result = devig_market(win_odds, format="american", method="shin")
+        assert sum(result.values()) == pytest.approx(1.0, abs=1e-5)
+
+    def test_all_methods(self, win_odds):
+        for method in ["shin", "multiplicative", "power"]:
+            result = devig_market(win_odds, format="american", method=method)
+            assert sum(result.values()) == pytest.approx(1.0, abs=1e-4)
+
+    def test_decimal_format(self):
+        odds = {"A": 2.0, "B": 3.0, "C": 6.0}  # sum implied = 1.0 + overlap
+        # 1/2 + 1/3 + 1/6 = 1.0 exactly — no vig
+        result = devig_market(odds, format="decimal", method="multiplicative")
+        assert result["A"] == pytest.approx(0.5, abs=1e-5)
+
+    def test_unknown_format_raises(self, win_odds):
+        with pytest.raises(ValueError):
+            devig_market(win_odds, format="unknown")
+
+    def test_unknown_method_raises(self, win_odds):
+        with pytest.raises(ValueError):
+            devig_market(win_odds, format="american", method="unknown")

--- a/pipeline/tests/test_odds_fetcher.py
+++ b/pipeline/tests/test_odds_fetcher.py
@@ -1,0 +1,143 @@
+"""Tests for odds_fetcher.py — driver resolution and odds processing."""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import json
+import tempfile
+import pytest
+from odds_fetcher import (
+    resolve_driver_index,
+    load_manual_odds,
+    process_odds_to_fair_probs,
+)
+from config import DRIVERS, N_DRIVERS
+
+
+class TestResolveDriverIndex:
+    def test_full_name(self):
+        assert resolve_driver_index("George Russell") == 0
+
+    def test_last_name(self):
+        assert resolve_driver_index("Russell") == 0
+
+    def test_abbreviation(self):
+        assert resolve_driver_index("RUS") == 0
+
+    def test_case_insensitive(self):
+        assert resolve_driver_index("george russell") == 0
+        assert resolve_driver_index("RUSSELL") == 0
+
+    def test_all_drivers_resolvable(self):
+        for i, d in enumerate(DRIVERS):
+            assert resolve_driver_index(d["name"]) == i
+            assert resolve_driver_index(d["abbr"]) == i
+
+    def test_hulkenberg_without_umlaut(self):
+        assert resolve_driver_index("Hulkenberg") is not None
+
+    def test_unknown_returns_none(self):
+        assert resolve_driver_index("Michael Schumacher") is None
+
+    def test_whitespace_stripped(self):
+        assert resolve_driver_index("  Russell  ") == 0
+
+
+class TestLoadManualOdds:
+    def test_loads_valid_json(self):
+        data = {
+            "race": "Test GP",
+            "date": "2026-01-01",
+            "is_sprint": False,
+            "markets": {"win": {"Russell": -150}},
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+            result = load_manual_odds(f.name)
+        assert result["race"] == "Test GP"
+        assert "win" in result["markets"]
+        os.unlink(f.name)
+
+
+class TestProcessOddsToFairProbs:
+    @pytest.fixture
+    def win_odds(self):
+        return {
+            "win": {
+                "Russell": -150,
+                "Antonelli": 200,
+                "Leclerc": 600,
+                "Hamilton": 800,
+            }
+        }
+
+    def test_win_market_sums_to_one(self, win_odds):
+        result = process_odds_to_fair_probs(win_odds)
+        probs = result["win"]
+        assert sum(probs.values()) == pytest.approx(1.0, abs=1e-4)
+
+    def test_win_market_uses_driver_indices(self, win_odds):
+        result = process_odds_to_fair_probs(win_odds)
+        # Russell is driver index 0
+        assert 0 in result["win"]
+
+    def test_win_favorite_has_highest_prob(self, win_odds):
+        result = process_odds_to_fair_probs(win_odds)
+        probs = result["win"]
+        # Russell at -150 should be the favorite
+        assert probs[0] == max(probs.values())
+
+    def test_placement_market(self):
+        raw = {
+            "podium": {
+                "Russell": -300,
+                "Antonelli": -200,
+                "Leclerc": 120,
+                "Hamilton": 150,
+            }
+        }
+        result = process_odds_to_fair_probs(raw)
+        probs = result["podium"]
+        # Podium probs should sum to ~3 (3 podium slots)
+        assert sum(probs.values()) == pytest.approx(3.0, abs=0.5)
+
+    def test_dnf_market(self):
+        raw = {
+            "dnf": {
+                "Russell": 1200,  # low DNF chance
+                "Verstappen": 500,  # higher DNF chance
+            }
+        }
+        result = process_odds_to_fair_probs(raw)
+        dnf = result["dnf"]
+        # Verstappen at +500 should have higher DNF prob than Russell at +1200
+        ver_idx = resolve_driver_index("Verstappen")
+        rus_idx = resolve_driver_index("Russell")
+        assert dnf[ver_idx] > dnf[rus_idx]
+
+    def test_unknown_driver_skipped(self):
+        raw = {"win": {"Russell": -150, "UnknownDriver": 5000}}
+        result = process_odds_to_fair_probs(raw)
+        # Should still work, just fewer drivers
+        assert 0 in result["win"]  # Russell resolved
+        assert len(result["win"]) == 1  # Unknown skipped
+
+    def test_empty_market_skipped(self):
+        result = process_odds_to_fair_probs({"win": {}})
+        assert "win" not in result
+
+    def test_full_manual_file(self):
+        """Process the actual Japanese GP odds file."""
+        filepath = os.path.join(
+            os.path.dirname(__file__), "..", "..", "public", "data", "odds_input", "japanese-gp-2026.json"
+        )
+        if not os.path.exists(filepath):
+            pytest.skip("Manual odds file not found")
+        with open(filepath) as f:
+            data = json.load(f)
+        result = process_odds_to_fair_probs(data["markets"])
+        assert "win" in result
+        assert len(result["win"]) >= 20  # Most drivers should resolve
+        assert sum(result["win"].values()) == pytest.approx(1.0, abs=1e-3)

--- a/pipeline/tests/test_plackett_luce.py
+++ b/pipeline/tests/test_plackett_luce.py
@@ -1,0 +1,290 @@
+"""Tests for plackett_luce.py — simulation, expected points, and model fitting."""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pytest
+from plackett_luce import (
+    simulate_races,
+    compute_expected_points,
+    compute_variance,
+    generate_full_output,
+    find_top_lineups,
+)
+from config import RACE_POINTS, SPRINT_POINTS, DNF_PENALTY, DRIVERS, N_DRIVERS, N_TEAMS
+
+
+@pytest.fixture
+def simple_lambdas():
+    """3 drivers with clear strength ordering."""
+    return np.log(np.array([3.0, 2.0, 1.0]))
+
+
+@pytest.fixture
+def simple_dnfs():
+    """3 drivers with low DNF rates."""
+    return np.array([0.05, 0.05, 0.05])
+
+
+@pytest.fixture
+def full_grid_lambdas():
+    """22 drivers with realistic strength spread."""
+    rng = np.random.default_rng(42)
+    return np.sort(rng.normal(0, 1, N_DRIVERS))[::-1]  # strongest first
+
+
+@pytest.fixture
+def full_grid_dnfs():
+    return np.full(N_DRIVERS, 0.10)
+
+
+@pytest.fixture
+def team_indices():
+    return np.array([d["team_idx"] for d in DRIVERS])
+
+
+# --- simulate_races ---
+
+class TestSimulateRaces:
+    def test_output_shape(self, simple_lambdas, simple_dnfs):
+        result = simulate_races(simple_lambdas, simple_dnfs, n_sims=1000)
+        n = len(simple_lambdas)
+        assert result.shape == (n, n + 1)  # positions + DNF column
+
+    def test_rows_sum_to_one(self, simple_lambdas, simple_dnfs):
+        result = simulate_races(simple_lambdas, simple_dnfs, n_sims=5000)
+        for i in range(len(simple_lambdas)):
+            assert result[i].sum() == pytest.approx(1.0, abs=0.01)
+
+    def test_strongest_driver_wins_most(self, simple_lambdas, simple_dnfs):
+        result = simulate_races(simple_lambdas, simple_dnfs, n_sims=10000)
+        # Driver 0 (λ=3) should win more than driver 2 (λ=1)
+        assert result[0, 0] > result[2, 0]
+
+    def test_dnf_probability_respected(self):
+        lambdas = np.zeros(3)
+        high_dnf = np.array([0.5, 0.5, 0.5])
+        result = simulate_races(lambdas, high_dnf, n_sims=10000)
+        # Each driver should DNF ~50% of the time
+        for i in range(3):
+            assert result[i, -1] == pytest.approx(0.5, abs=0.05)
+
+    def test_zero_dnf(self):
+        lambdas = np.zeros(3)
+        zero_dnf = np.array([0.0, 0.0, 0.0])
+        result = simulate_races(lambdas, zero_dnf, n_sims=1000)
+        # No DNFs
+        for i in range(3):
+            assert result[i, -1] == 0.0
+
+    def test_deterministic_with_seed(self, simple_lambdas, simple_dnfs):
+        r1 = simulate_races(simple_lambdas, simple_dnfs, n_sims=1000, seed=123)
+        r2 = simulate_races(simple_lambdas, simple_dnfs, n_sims=1000, seed=123)
+        np.testing.assert_array_equal(r1, r2)
+
+    def test_different_seeds_differ(self, simple_lambdas, simple_dnfs):
+        r1 = simulate_races(simple_lambdas, simple_dnfs, n_sims=1000, seed=1)
+        r2 = simulate_races(simple_lambdas, simple_dnfs, n_sims=1000, seed=2)
+        assert not np.array_equal(r1, r2)
+
+    def test_equal_lambdas_uniform(self):
+        """Equal-strength drivers should have ~equal win probabilities."""
+        lambdas = np.zeros(4)  # all log(1) = 0
+        dnfs = np.zeros(4)
+        result = simulate_races(lambdas, dnfs, n_sims=20000)
+        # Each driver should win ~25% of the time
+        for i in range(4):
+            assert result[i, 0] == pytest.approx(0.25, abs=0.03)
+
+    def test_full_grid(self, full_grid_lambdas, full_grid_dnfs):
+        result = simulate_races(full_grid_lambdas, full_grid_dnfs, n_sims=5000)
+        assert result.shape == (N_DRIVERS, N_DRIVERS + 1)
+        for i in range(N_DRIVERS):
+            assert result[i].sum() == pytest.approx(1.0, abs=0.01)
+
+    def test_with_correlation(self, full_grid_lambdas, full_grid_dnfs, team_indices):
+        correlation = {"sigma_team": 0.5, "sigma_global": 0.3, "sigma_dnf": 0.2}
+        result = simulate_races(
+            full_grid_lambdas, full_grid_dnfs, n_sims=5000,
+            team_indices=team_indices, correlation=correlation,
+        )
+        assert result.shape == (N_DRIVERS, N_DRIVERS + 1)
+        for i in range(N_DRIVERS):
+            assert result[i].sum() == pytest.approx(1.0, abs=0.01)
+
+
+# --- compute_expected_points ---
+
+class TestComputeExpectedPoints:
+    def test_certain_winner(self):
+        """If a driver wins 100% of the time, EP = P1 points."""
+        dist = np.zeros(23)
+        dist[0] = 1.0  # Always P1
+        ep = compute_expected_points(dist, RACE_POINTS)
+        assert ep == 25.0
+
+    def test_certain_dnf(self):
+        """If a driver always DNFs, EP = DNF penalty."""
+        dist = np.zeros(23)
+        dist[-1] = 1.0
+        ep = compute_expected_points(dist, RACE_POINTS)
+        assert ep == DNF_PENALTY
+
+    def test_certain_p11(self):
+        """P11 scores 0 points."""
+        dist = np.zeros(23)
+        dist[10] = 1.0  # P11
+        ep = compute_expected_points(dist, RACE_POINTS)
+        assert ep == 0.0
+
+    def test_50_50_win_or_dnf(self):
+        dist = np.zeros(23)
+        dist[0] = 0.5
+        dist[-1] = 0.5
+        ep = compute_expected_points(dist, RACE_POINTS)
+        assert ep == pytest.approx(0.5 * 25 + 0.5 * DNF_PENALTY)
+
+    def test_sprint_scoring(self):
+        dist = np.zeros(23)
+        dist[0] = 1.0
+        ep = compute_expected_points(dist, SPRINT_POINTS)
+        assert ep == 8.0
+
+
+# --- compute_variance ---
+
+class TestComputeVariance:
+    def test_certain_outcome_zero_variance(self):
+        dist = np.zeros(23)
+        dist[0] = 1.0
+        var = compute_variance(dist, RACE_POINTS)
+        assert var == pytest.approx(0.0)
+
+    def test_positive_variance_for_mixed(self):
+        dist = np.zeros(23)
+        dist[0] = 0.5
+        dist[-1] = 0.5
+        var = compute_variance(dist, RACE_POINTS)
+        assert var > 0
+
+    def test_variance_formula(self):
+        """Manual check: 50% P1 (25pts), 50% DNF (-10pts)."""
+        dist = np.zeros(23)
+        dist[0] = 0.5
+        dist[-1] = 0.5
+        ep = 0.5 * 25 + 0.5 * DNF_PENALTY
+        expected_var = 0.5 * (25 - ep) ** 2 + 0.5 * (DNF_PENALTY - ep) ** 2
+        var = compute_variance(dist, RACE_POINTS)
+        assert var == pytest.approx(expected_var)
+
+
+# --- generate_full_output ---
+
+class TestGenerateFullOutput:
+    def test_returns_22_drivers(self, full_grid_lambdas, full_grid_dnfs, team_indices):
+        output = generate_full_output(
+            full_grid_lambdas, full_grid_dnfs, n_sims=2000,
+            team_indices=team_indices,
+        )
+        assert len(output) == N_DRIVERS
+
+    def test_sorted_by_ep_total(self, full_grid_lambdas, full_grid_dnfs, team_indices):
+        output = generate_full_output(
+            full_grid_lambdas, full_grid_dnfs, n_sims=2000,
+            team_indices=team_indices,
+        )
+        totals = [d["ep_total"] for d in output]
+        assert totals == sorted(totals, reverse=True)
+
+    def test_required_fields(self, full_grid_lambdas, full_grid_dnfs, team_indices):
+        output = generate_full_output(
+            full_grid_lambdas, full_grid_dnfs, n_sims=2000,
+            team_indices=team_indices,
+        )
+        required = {
+            "name", "abbr", "team_idx", "lambda", "p_dnf",
+            "ep_race", "ep_sprint", "ep_total", "std_dev",
+            "p_win", "p_podium", "p_top6", "p_top10",
+            "p_no_points", "position_distribution",
+        }
+        for d in output:
+            assert required.issubset(d.keys())
+
+    def test_position_distribution_length(self, full_grid_lambdas, full_grid_dnfs, team_indices):
+        output = generate_full_output(
+            full_grid_lambdas, full_grid_dnfs, n_sims=2000,
+            team_indices=team_indices,
+        )
+        for d in output:
+            assert len(d["position_distribution"]) == N_DRIVERS + 1
+
+    def test_probabilities_valid(self, full_grid_lambdas, full_grid_dnfs, team_indices):
+        output = generate_full_output(
+            full_grid_lambdas, full_grid_dnfs, n_sims=2000,
+            team_indices=team_indices,
+        )
+        for d in output:
+            assert 0 <= d["p_win"] <= 1
+            assert 0 <= d["p_podium"] <= 1
+            assert 0 <= d["p_top6"] <= 1
+            assert 0 <= d["p_top10"] <= 1
+            assert d["p_win"] <= d["p_podium"] <= d["p_top6"] <= d["p_top10"]
+
+    def test_sprint_adds_points(self, full_grid_lambdas, full_grid_dnfs, team_indices):
+        output_no_sprint = generate_full_output(
+            full_grid_lambdas, full_grid_dnfs, is_sprint=False, n_sims=2000,
+            team_indices=team_indices,
+        )
+        output_sprint = generate_full_output(
+            full_grid_lambdas, full_grid_dnfs, is_sprint=True, n_sims=2000,
+            team_indices=team_indices,
+        )
+        # Sprint weekend should add ep_sprint > 0 for top drivers
+        top_sprint = max(d["ep_sprint"] for d in output_sprint)
+        top_no_sprint = max(d["ep_sprint"] for d in output_no_sprint)
+        assert top_sprint > 0
+        assert top_no_sprint == 0
+
+
+# --- find_top_lineups ---
+
+class TestFindTopLineups:
+    @pytest.fixture
+    def drivers_data(self, full_grid_lambdas, full_grid_dnfs, team_indices):
+        return generate_full_output(
+            full_grid_lambdas, full_grid_dnfs, n_sims=2000,
+            team_indices=team_indices,
+        )
+
+    def test_returns_requested_count(self, drivers_data):
+        lineups = find_top_lineups(drivers_data, top_n=5)
+        assert len(lineups) == 5
+
+    def test_ranked_in_order(self, drivers_data):
+        lineups = find_top_lineups(drivers_data, top_n=10)
+        for i, lineup in enumerate(lineups):
+            assert lineup["rank"] == i + 1
+
+    def test_grand_total_decreasing(self, drivers_data):
+        lineups = find_top_lineups(drivers_data, top_n=10)
+        totals = [l["ep_grand_total"] for l in lineups]
+        assert totals == sorted(totals, reverse=True)
+
+    def test_five_picks_per_lineup(self, drivers_data):
+        lineups = find_top_lineups(drivers_data, n_picks=5, top_n=3)
+        for lineup in lineups:
+            assert len(lineup["picks"]) == 5
+
+    def test_slots_1_through_5(self, drivers_data):
+        lineups = find_top_lineups(drivers_data, n_picks=5, top_n=3)
+        for lineup in lineups:
+            slots = sorted(p["slot"] for p in lineup["picks"])
+            assert slots == [1, 2, 3, 4, 5]
+
+    def test_grand_total_equals_base_plus_bonus(self, drivers_data):
+        lineups = find_top_lineups(drivers_data, top_n=3)
+        for lineup in lineups:
+            expected = lineup["ep_base_total"] + lineup["ep_bonus_total"]
+            assert lineup["ep_grand_total"] == pytest.approx(expected, abs=0.02)

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -20,7 +20,8 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.1.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -850,6 +851,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -860,6 +868,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -919,6 +945,119 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -983,6 +1122,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1079,6 +1228,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1194,6 +1353,13 @@
       "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1392,6 +1558,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1400,6 +1576,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2022,6 +2208,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2073,6 +2269,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2157,6 +2364,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2338,6 +2552,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2347,6 +2568,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -2374,6 +2609,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2389,6 +2641,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2531,6 +2793,88 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2545,6 +2889,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^19.2.4",
@@ -22,6 +23,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.2"
   }
 }

--- a/site/src/lib/simulation.js
+++ b/site/src/lib/simulation.js
@@ -121,8 +121,9 @@ export function simulateRaces(
     // PL sequential draw
     const remaining = [...finishers];
     const remLambdas = remaining.map(i => simLambdas[i]);
+    const nFinishers = remaining.length;
 
-    for (let pos = 0; pos < remaining.length; pos++) {
+    for (let pos = 0; pos < nFinishers; pos++) {
       const chosenLocal = weightedChoice(remLambdas, rand);
       const chosenDriver = remaining[chosenLocal];
       counts[chosenDriver][pos] += 1;

--- a/site/src/lib/simulation.test.js
+++ b/site/src/lib/simulation.test.js
@@ -1,0 +1,151 @@
+/**
+ * Tests for simulation.js — client-side Plackett-Luce simulator.
+ */
+
+import { describe, it, expect } from "vitest";
+import { simulateRaces, computeExpectedPoints } from "./simulation.js";
+
+// --- simulateRaces ---
+
+describe("simulateRaces", () => {
+  it("returns correct shape for 3 drivers", () => {
+    const logLambdas = [Math.log(3), Math.log(2), Math.log(1)];
+    const pDnfs = [0.05, 0.05, 0.05];
+    const result = simulateRaces(logLambdas, pDnfs, 1000, 42);
+    expect(result.length).toBe(3);
+    // Each driver has 4 entries: P1, P2, P3, DNF
+    expect(result[0].length).toBe(4);
+  });
+
+  it("rows sum to approximately 1", () => {
+    const logLambdas = [0.5, 0, -0.5];
+    const pDnfs = [0.05, 0.05, 0.05];
+    const result = simulateRaces(logLambdas, pDnfs, 5000, 42);
+    for (const row of result) {
+      const sum = row.reduce((a, b) => a + b, 0);
+      expect(sum).toBeCloseTo(1.0, 1);
+    }
+  });
+
+  it("strongest driver wins most often", () => {
+    const logLambdas = [Math.log(5), Math.log(2), Math.log(1)];
+    const pDnfs = [0.0, 0.0, 0.0];
+    const result = simulateRaces(logLambdas, pDnfs, 10000, 42);
+    // Driver 0 should win more than driver 2
+    expect(result[0][0]).toBeGreaterThan(result[2][0]);
+  });
+
+  it("respects DNF probabilities", () => {
+    const logLambdas = [0, 0, 0];
+    const pDnfs = [0.5, 0.5, 0.5];
+    const result = simulateRaces(logLambdas, pDnfs, 10000, 42);
+    for (let i = 0; i < 3; i++) {
+      // DNF is last entry
+      expect(result[i][3]).toBeCloseTo(0.5, 1);
+    }
+  });
+
+  it("zero DNF means no DNFs", () => {
+    const logLambdas = [0, 0, 0];
+    const pDnfs = [0, 0, 0];
+    const result = simulateRaces(logLambdas, pDnfs, 1000, 42);
+    for (let i = 0; i < 3; i++) {
+      expect(result[i][3]).toBe(0);
+    }
+  });
+
+  it("is deterministic with same seed", () => {
+    const logLambdas = [1, 0, -1];
+    const pDnfs = [0.1, 0.1, 0.1];
+    const r1 = simulateRaces(logLambdas, pDnfs, 1000, 42);
+    const r2 = simulateRaces(logLambdas, pDnfs, 1000, 42);
+    for (let i = 0; i < 3; i++) {
+      for (let j = 0; j < 4; j++) {
+        expect(r1[i][j]).toBe(r2[i][j]);
+      }
+    }
+  });
+
+  it("different seeds give different results", () => {
+    const logLambdas = [1, 0, -1];
+    const pDnfs = [0.1, 0.1, 0.1];
+    const r1 = simulateRaces(logLambdas, pDnfs, 1000, 1);
+    const r2 = simulateRaces(logLambdas, pDnfs, 1000, 2);
+    // At least one value should differ
+    let differs = false;
+    for (let i = 0; i < 3 && !differs; i++) {
+      for (let j = 0; j < 4 && !differs; j++) {
+        if (r1[i][j] !== r2[i][j]) differs = true;
+      }
+    }
+    expect(differs).toBe(true);
+  });
+
+  it("equal lambdas give roughly equal win rates", () => {
+    const logLambdas = [0, 0, 0, 0];
+    const pDnfs = [0, 0, 0, 0];
+    const result = simulateRaces(logLambdas, pDnfs, 20000, 42);
+    for (let i = 0; i < 4; i++) {
+      expect(result[i][0]).toBeCloseTo(0.25, 1);
+    }
+  });
+
+  it("works with correlation parameters", () => {
+    const logLambdas = [1, 0.8, 0, -0.2, -1, -1.2];
+    const pDnfs = [0.05, 0.05, 0.05, 0.05, 0.05, 0.05];
+    const teamIndices = [0, 0, 1, 1, 2, 2];
+    const correlation = { sigma_team: 0.5, sigma_global: 0.3, sigma_dnf: 0.2 };
+    const result = simulateRaces(logLambdas, pDnfs, 5000, 42, teamIndices, correlation);
+    expect(result.length).toBe(6);
+    expect(result[0].length).toBe(7); // 6 positions + DNF
+    for (const row of result) {
+      const sum = row.reduce((a, b) => a + b, 0);
+      expect(sum).toBeCloseTo(1.0, 1);
+    }
+  });
+});
+
+// --- computeExpectedPoints ---
+
+describe("computeExpectedPoints", () => {
+  const raceScoring = {
+    "1": 25, "2": 18, "3": 15, "4": 12, "5": 10,
+    "6": 8, "7": 6, "8": 4, "9": 2, "10": 1,
+  };
+
+  it("certain winner gets 25 points", () => {
+    // 22 positions + DNF = 23 entries
+    const dist = new Array(23).fill(0);
+    dist[0] = 1.0;
+    expect(computeExpectedPoints(dist, raceScoring, -10)).toBe(25);
+  });
+
+  it("certain DNF gets penalty", () => {
+    const dist = new Array(23).fill(0);
+    dist[22] = 1.0;
+    expect(computeExpectedPoints(dist, raceScoring, -10)).toBe(-10);
+  });
+
+  it("50/50 win or DNF", () => {
+    const dist = new Array(23).fill(0);
+    dist[0] = 0.5;
+    dist[22] = 0.5;
+    const ep = computeExpectedPoints(dist, raceScoring, -10);
+    expect(ep).toBeCloseTo(0.5 * 25 + 0.5 * -10, 5);
+  });
+
+  it("P11 scores zero", () => {
+    const dist = new Array(23).fill(0);
+    dist[10] = 1.0; // P11
+    expect(computeExpectedPoints(dist, raceScoring, -10)).toBe(0);
+  });
+
+  it("sprint scoring", () => {
+    const sprintScoring = {
+      "1": 8, "2": 7, "3": 6, "4": 5, "5": 4, "6": 3, "7": 2, "8": 1,
+    };
+    const dist = new Array(23).fill(0);
+    dist[0] = 1.0;
+    expect(computeExpectedPoints(dist, sprintScoring, -10)).toBe(8);
+  });
+});


### PR DESCRIPTION
- 105 Python tests (pytest) covering devig methods, config consistency,
  odds fetcher driver resolution/processing, and Plackett-Luce simulation,
  expected points, variance, full output generation, and lineup finder
- 14 JS tests (vitest) covering client-side simulateRaces and
  computeExpectedPoints
- Fix bug in simulation.js where PL sequential draw loop terminated early
  because remaining.length shrank via splice while pos incremented
- Add vitest devDependency and test script to site/package.json

https://claude.ai/code/session_01LYU4ABQEzG5sjhZZtbS9Mr