### PR TITLE
Add Dashboard navigation link to Nav component

### DIFF
--- a/site/src/components/Nav.jsx
+++ b/site/src/components/Nav.jsx
@@ -26,6 +26,12 @@ export default function Nav({ page, setPage, race, races, selectedRace, onRaceCh
       </div>
       <div className="nav-links">
         <button
+          className={`nav-link ${page === 'dashboard' ? 'active' : ''}`}
+          onClick={() => setPage('dashboard')}
+        >
+          Dashboard
+        </button>
+        <button
           className={`nav-link ${page === 'methodology' ? 'active' : ''}`}
           onClick={() => setPage('methodology')}
         >


### PR DESCRIPTION
## Summary
Added a new "Dashboard" navigation link to the Nav component, allowing users to navigate to the dashboard page.

## Key Changes
- Added a new navigation button for the "Dashboard" page in the nav-links section
- The button includes conditional styling to show an "active" state when the current page is 'dashboard'
- Positioned before the existing "Methodology" link in the navigation menu

## Implementation Details
The Dashboard link follows the same pattern as existing navigation buttons:
- Uses the `nav-link` className with conditional `active` class based on current page state
- Calls `setPage('dashboard')` when clicked to update the current page
- Integrates seamlessly with the existing page navigation system

https://claude.ai/code/session_0136nAW92bwsbMHT5ecc39nM