### PR TITLE
Sprint weekend: dual PL fit, per-event lineups, DNF penalty fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,15 @@ This is NOT the official F1 Fantasy game. Our family league uses simplified scor
 
 **Grand Prix race finish:**
 - P1=25, P2=18, P3=15, P4=12, P5=10, P6=8, P7=6, P8=4, P9=2, P10=1, P11-P22=0
-- DNF/NC = **-20 points**
+- DNF/NC = **-10 points**
 
 **Sprint race finish (6 weekends: China, Miami, Canada, Great Britain, Netherlands, Singapore):**
 - P1=8, P2=7, P3=6, P4=5, P5=4, P6=3, P7=2, P8=1, P9+=0
-- DNF/NC = **-20 points**
+- DNF/NC = **-10 points**
 
-**That's it.** No qualifying points, no positions gained, no overtakes, no fastest lap bonus, no Driver of the Day. Each player picks 5 drivers before qualifying each weekend (same drivers for sprint + race). No budget cap.
+**Exact-position pick bonus:** each player submits 5 picks in slots 1–5; a pick in slot N earns **+10 bonus points** when that driver finishes in position N. The bonus is awarded per event — on a sprint weekend the same pick can earn the bonus once for the sprint and once for the Grand Prix.
+
+**That's it.** No qualifying points, no positions gained, no overtakes, no fastest lap bonus, no Driver of the Day. Each player picks 5 drivers before qualifying each weekend (same drivers for sprint + race). No budget cap. Source of truth for scoring constants is the league's `scorer.py` (mirrored in `pipeline/config.py`).
 
 ## Architecture
 

--- a/pipeline/backfill_dnf_penalty.py
+++ b/pipeline/backfill_dnf_penalty.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Backfill old race-output JSON files for the DNF penalty correction.
+
+Context: the league's actual DNF penalty is -10, but the pipeline used -20
+until this PR. Every existing race output therefore has wrong ep_race /
+ep_sprint / ep_total / std_dev / lineup numbers. Position distributions are
+correct (the simulator didn't change), so we can recompute everything
+downstream from each file's existing position_distribution arrays without
+re-simulating.
+
+Scope: rewrites the per-race latest snapshots only —
+  public/data/latest.json
+  public/data/races/<slug>.json
+
+Timestamped snapshots under public/data/races/<slug>/<ts>.json are left
+untouched: they're historical "what we predicted at the time" artifacts and
+shouldn't be silently rewritten.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List
+
+# Allow running from repo root or pipeline/.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from config import RACE_POINTS, SPRINT_POINTS, DNF_PENALTY, EXACT_BONUS
+from plackett_luce import (
+    compute_expected_points, compute_variance, find_top_lineups,
+)
+import numpy as np
+
+
+def _coerce_points_table(raw: dict) -> Dict[int, int]:
+    """JSON keys are strings — coerce back to int → int."""
+    return {int(k): int(v) for k, v in (raw or {}).items()}
+
+
+def _recompute_driver(d: dict, race_points: Dict[int, int],
+                      sprint_points: Dict[int, int], is_sprint: bool,
+                      dnf_penalty: int) -> dict:
+    """Recompute ep_*/std_dev for one driver from its existing distribution."""
+    dist = np.array(d["position_distribution"], dtype=np.float64)
+    ep_race = compute_expected_points(dist, race_points, dnf_penalty=dnf_penalty)
+    ep_sprint = (compute_expected_points(dist, sprint_points, dnf_penalty=dnf_penalty)
+                 if is_sprint else 0.0)
+    var_race = compute_variance(dist, race_points, dnf_penalty=dnf_penalty)
+
+    # If the file has a sprint-specific distribution (post-dual-fit files),
+    # use it for sprint EP. This branch is currently a no-op for old files
+    # but keeps the script idempotent on newer files.
+    if "position_distribution_sprint" in d and is_sprint:
+        sprint_dist = np.array(d["position_distribution_sprint"], dtype=np.float64)
+        ep_sprint = compute_expected_points(sprint_dist, sprint_points, dnf_penalty=dnf_penalty)
+        var_sprint = compute_variance(sprint_dist, sprint_points, dnf_penalty=dnf_penalty)
+        d["std_dev_sprint"] = round(float(np.sqrt(var_sprint)), 2)
+
+    d["ep_race"] = round(float(ep_race), 2)
+    d["ep_sprint"] = round(float(ep_sprint), 2)
+    d["ep_total"] = round(float(ep_race + ep_sprint), 2)
+    d["std_dev"] = round(float(np.sqrt(var_race)), 2)
+    return d
+
+
+def backfill_file(path: Path, dry_run: bool = False) -> bool:
+    """Rewrite one race-output JSON in place. Returns True if changed."""
+    try:
+        with path.open() as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"  SKIP {path}: {e}")
+        return False
+
+    if "drivers" not in data or "scoring" not in data:
+        print(f"  SKIP {path}: not a race-output file")
+        return False
+
+    old_dnf = data["scoring"].get("dnf_penalty")
+    if old_dnf == DNF_PENALTY and data["scoring"].get("exact_bonus") == EXACT_BONUS:
+        print(f"  OK   {path} (already at DNF={DNF_PENALTY}, EXACT_BONUS={EXACT_BONUS})")
+        return False
+
+    race_points = _coerce_points_table(data["scoring"].get("race", RACE_POINTS))
+    sprint_points = _coerce_points_table(data["scoring"].get("sprint", SPRINT_POINTS))
+    is_sprint = bool(data.get("meta", {}).get("is_sprint", False))
+
+    # Recompute per-driver EPs / std_dev.
+    for d in data["drivers"]:
+        _recompute_driver(d, race_points, sprint_points, is_sprint, DNF_PENALTY)
+    data["drivers"].sort(key=lambda d: -d["ep_total"])
+
+    # Recompute combined lineups. We can only do the combined slice for old
+    # single-fit files (no per-event distributions). If a file already has
+    # split distributions, recompute all three.
+    has_dual = any("position_distribution_sprint" in d for d in data["drivers"])
+
+    data["top_lineups"] = find_top_lineups(
+        data["drivers"], top_n=len(data.get("top_lineups") or []) or 10,
+        score_key="ep_total",
+        dist_keys=(("position_distribution", "position_distribution_sprint")
+                   if has_dual else ("position_distribution",)),
+    )
+    if has_dual:
+        data["top_lineups_race"] = find_top_lineups(
+            data["drivers"], top_n=len(data.get("top_lineups_race") or []) or 10,
+            score_key="ep_race", dist_keys=("position_distribution",),
+        )
+        data["top_lineups_sprint"] = find_top_lineups(
+            data["drivers"], top_n=len(data.get("top_lineups_sprint") or []) or 10,
+            score_key="ep_sprint", dist_keys=("position_distribution_sprint",),
+        )
+
+    data["scoring"]["dnf_penalty"] = DNF_PENALTY
+    data["scoring"]["exact_bonus"] = EXACT_BONUS
+    data.setdefault("meta", {})["backfilled_at"] = datetime.now(timezone.utc).isoformat()
+    data["meta"]["backfill_note"] = (
+        f"DNF penalty corrected from {old_dnf} to {DNF_PENALTY}; per-driver EPs "
+        f"and lineups recomputed from existing position_distribution arrays."
+    )
+
+    if dry_run:
+        d0 = data["drivers"][0]
+        print(f"  DRY  {path}: top driver {d0['abbr']} ep_total={d0['ep_total']}")
+        return True
+
+    with path.open("w") as f:
+        json.dump(data, f, indent=2)
+    d0 = data["drivers"][0]
+    print(f"  OK   {path}: rewrote (top {d0['abbr']} ep_total={d0['ep_total']})")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", default="public/data",
+                        help="Repo data directory (default: public/data)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Compute new values and report, but don't write files")
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir).resolve()
+    if not data_dir.exists():
+        print(f"ERROR: {data_dir} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    # Targets: public/data/latest.json + public/data/races/*.json (NOT the
+    # timestamped snapshots under public/data/races/<slug>/<ts>.json).
+    targets: List[Path] = []
+    latest = data_dir / "latest.json"
+    if latest.exists():
+        targets.append(latest)
+    races_dir = data_dir / "races"
+    if races_dir.exists():
+        for p in sorted(races_dir.glob("*.json")):
+            if p.name == "index.json":
+                continue
+            targets.append(p)
+
+    print(f"Backfilling {len(targets)} file(s) (dry_run={args.dry_run}):")
+    changed = 0
+    for path in targets:
+        if backfill_file(path, dry_run=args.dry_run):
+            changed += 1
+    print(f"\n{changed}/{len(targets)} file(s) {'would be ' if args.dry_run else ''}updated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -8,10 +8,15 @@ automatically. Only team *colors* are configured locally, since neither the
 F1 API nor Oddschecker exposes a color palette.
 """
 
-# Points scoring for family league
+# Points scoring for family league. Source of truth: the league's scorer.py
+# (lives outside this repo). If those constants change, mirror them here.
 RACE_POINTS = {1: 25, 2: 18, 3: 15, 4: 12, 5: 10, 6: 8, 7: 6, 8: 4, 9: 2, 10: 1}
 SPRINT_POINTS = {1: 8, 2: 7, 3: 6, 4: 5, 5: 4, 6: 3, 7: 2, 8: 1}
-DNF_PENALTY = -20
+DNF_PENALTY = -10
+# Exact-position pick bonus: a driver picked in slot N earns +EXACT_BONUS
+# whenever they finish position N. Awarded per event — on a sprint weekend the
+# same pick can earn the bonus once for the sprint and once for the race.
+EXACT_BONUS = 10
 
 # Team colors keyed by Jolpica's stable `constructorId` (lowercase, snake_case).
 # When a new team appears (or a team's id changes), it falls back to

--- a/pipeline/odds_fetcher.py
+++ b/pipeline/odds_fetcher.py
@@ -1,19 +1,26 @@
 """
-Odds fetcher: scrapes F1 race odds from Oddschecker via headless Chromium.
+Odds fetcher: scrapes F1 race + sprint odds from Oddschecker via headless Chromium.
 
 Manual JSON input is the fallback / override for markets the scraper doesn't
 cover. Both sources can be combined — manual overrides scraped for the same
 market.
 
-Markets scraped (when present):
+Markets scraped (per event, when present):
   - win    → race winner (outright)
   - podium → podium finish (top 3)
   - top5   → top-5 finish        (Oddschecker market: Top 5 Finish)
   - top10  → points finish       (Oddschecker market: Points Finish)
+  - dnf    → "Not To Be Classified" (binary per driver)
 
-Oddschecker no longer publishes a DNF market for F1. We fall back to a
-default per-driver DNF probability in the model fitter when one isn't
-provided.
+Sprint weekends:
+  When the schedule flags is_sprint, the scraper also visits the
+  `<race-slug>-sprint/...` paths (e.g. miami-grand-prix-sprint/winner) and
+  returns sprint odds under a separate event key. The dual-fit pipeline
+  fits a separate Plackett-Luce model per event.
+
+Return shape (event-keyed):
+  {"race":   {"win": {...}, "podium": {...}, ...},
+   "sprint": {"win": {...}, ...}}     # only on sprint weekends
 
 Race discovery:
   We derive the next-race slug from public/data/schedule.json rather than
@@ -59,6 +66,10 @@ MARKET_URL_CANDIDATES: Dict[str, List[str]] = {
     "podium": ["podium-finish"],
     "top5": ["top-5-finish"],
     "top10": ["points-finish"],
+    # Oddschecker re-introduced the DNF market under "Not To Be Classified".
+    # The slug also appears with hyphenation variants on some race pages.
+    "dnf": ["not-to-be-classified", "to-not-be-classified",
+            "driver-not-to-finish", "driver-to-retire", "to-retire"],
 }
 
 # Each market URL on Oddschecker actually renders several market accordions
@@ -71,6 +82,7 @@ MARKET_HEADING_TEXT: Dict[str, str] = {
     "podium": "Podium Finish",
     "top5": "Top 5 Finish",
     "top10": "Points Finish",
+    "dnf": "Not To Be Classified",
 }
 
 # Default page nav timeout (ms). Oddschecker is heavy; give it room.
@@ -475,12 +487,54 @@ def _next_race_from_schedule(
     }
 
 
-def fetch_all_f1_odds(headed: bool = False, debug_dir: Optional[str] = None) -> Tuple[Dict[str, Dict[str, float]], dict]:
+def _scrape_event_markets(
+    browser,
+    event_label: str,
+    base_url: str,
+    user_agent: str,
+    debug_dir: Optional[str] = None,
+) -> Dict[str, Dict[str, float]]:
+    """Scrape every market in MARKET_URL_CANDIDATES for one event under base_url.
+
+    base_url is e.g. ".../miami-grand-prix" for race or
+    ".../miami-grand-prix-sprint" for sprint. Returns {market: {driver: odds}}.
+    """
+    out: Dict[str, Dict[str, float]] = {}
+    for market_key, slugs in MARKET_URL_CANDIDATES.items():
+        print(f"\nScraping {event_label}/{market_key}...")
+        heading = MARKET_HEADING_TEXT[market_key]
+        for slug in slugs:
+            url = f"{base_url}/{slug}"
+            context = browser.new_context(
+                viewport={"width": 1366, "height": 900},
+                user_agent=user_agent,
+                locale="en-GB",
+            )
+            try:
+                page = context.new_page()
+                page.set_default_timeout(PAGE_TIMEOUT_MS)
+                odds = _scrape_market_page(page, url, heading, debug_dir=debug_dir)
+            finally:
+                try:
+                    context.close()
+                except Exception:
+                    pass
+            if odds:
+                out[market_key] = odds
+                break
+        if market_key not in out:
+            print(f"  {event_label}/{market_key}: no odds found across {len(slugs)} URL candidate(s)")
+    return out
+
+
+def fetch_all_f1_odds(headed: bool = False, debug_dir: Optional[str] = None) -> Tuple[Dict[str, Dict[str, Dict[str, float]]], dict]:
     """
     Scrape all available F1 markets for the next race from Oddschecker.
 
-    Returns (raw_odds_by_market, race_info) where raw_odds_by_market maps
-    'win'/'podium'/'top6'/'dnf' → { driver_name: american_odds }.
+    Returns (raw_odds_by_event, race_info) where raw_odds_by_event maps
+    'race'/'sprint' → {market: {driver_name: american_odds}}. The 'sprint'
+    key is only populated on sprint weekends where Oddschecker exposes a
+    /…-sprint/* market path.
 
     A fresh browser context is opened for each market URL attempt: a single
     bad URL (redirect, 403) on Oddschecker poisons the session via Cloudflare
@@ -505,9 +559,12 @@ def fetch_all_f1_odds(headed: bool = False, debug_dir: Optional[str] = None) -> 
         "is_sprint": next_race["is_sprint"],
     }
     race_url = f"{ODDSCHECKER_BASE}/{next_race['slug']}"
+    sprint_url = f"{race_url}-sprint" if next_race["is_sprint"] else None
     print(f"  next race: {next_race['name']} ({race_url})")
+    if sprint_url:
+        print(f"  sprint event: {sprint_url}")
 
-    raw_odds: Dict[str, Dict[str, float]] = {}
+    raw_odds: Dict[str, Dict[str, Dict[str, float]]] = {}
 
     user_agent = (
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
@@ -517,30 +574,18 @@ def fetch_all_f1_odds(headed: bool = False, debug_dir: Optional[str] = None) -> 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=not headed)
         try:
-            for market_key, slugs in MARKET_URL_CANDIDATES.items():
-                print(f"\nScraping {market_key} market...")
-                heading = MARKET_HEADING_TEXT[market_key]
-                for slug in slugs:
-                    url = f"{race_url}/{slug}"
-                    context = browser.new_context(
-                        viewport={"width": 1366, "height": 900},
-                        user_agent=user_agent,
-                        locale="en-GB",
-                    )
-                    try:
-                        page = context.new_page()
-                        page.set_default_timeout(PAGE_TIMEOUT_MS)
-                        odds = _scrape_market_page(page, url, heading, debug_dir=debug_dir)
-                    finally:
-                        try:
-                            context.close()
-                        except Exception:
-                            pass
-                    if odds:
-                        raw_odds[market_key] = odds
-                        break
-                if market_key not in raw_odds:
-                    print(f"  {market_key}: no odds found across {len(slugs)} URL candidate(s)")
+            race_markets = _scrape_event_markets(
+                browser, "race", race_url, user_agent, debug_dir=debug_dir,
+            )
+            if race_markets:
+                raw_odds["race"] = race_markets
+
+            if sprint_url:
+                sprint_markets = _scrape_event_markets(
+                    browser, "sprint", sprint_url, user_agent, debug_dir=debug_dir,
+                )
+                if sprint_markets:
+                    raw_odds["sprint"] = sprint_markets
         finally:
             browser.close()
 
@@ -556,27 +601,24 @@ def load_manual_odds(filepath: str) -> dict:
     """
     Load manually-entered odds from a JSON file.
 
-    Expected format: see CLAUDE.md "Manual Odds Input Template"
+    Two supported shapes:
+      1. Single-event (race-only):
+         { "markets": { "win": {...}, "podium": {...}, ... } }
+      2. Dual-event (sprint weekend, separate sprint odds):
+         { "markets_race": {...}, "markets_sprint": {...} }
+         (or `markets` may still be present and is treated as race odds)
+
+    See CLAUDE.md "Manual Odds Input Template" for examples.
     """
     with open(filepath) as f:
         data = json.load(f)
     return data
 
 
-def process_odds_to_fair_probs(
-    raw_odds: dict,
-    name_map: Dict[str, int],
-    devig_method: str = "shin",
-) -> Dict[str, Dict[int, float]]:
-    """
-    Convert raw odds (from scraper or manual) into fair probabilities mapped to
-    roster indices. `name_map` is built from the active roster via
-    roster.build_name_map; any odds-source name that doesn't resolve to a
-    roster slot is dropped with a warning.
-    """
-    observed_probs = {}
-
-    for market_name, market_odds in raw_odds.items():
+def _process_one_event(event_odds: dict, name_map: Dict[str, int], devig_method: str) -> Dict[str, Dict[int, float]]:
+    """Devig + map names→idx for one event's markets."""
+    observed_probs: Dict[str, Dict[int, float]] = {}
+    for market_name, market_odds in event_odds.items():
         if not market_odds:
             continue
 
@@ -637,6 +679,21 @@ def process_odds_to_fair_probs(
     return observed_probs
 
 
+def process_odds_to_fair_probs(
+    raw_odds: dict,
+    name_map: Dict[str, int],
+    devig_method: str = "shin",
+) -> Dict[str, Dict[str, Dict[int, float]]]:
+    """
+    Convert raw event-keyed odds into fair probabilities mapped to roster
+    indices. Returns {event: {market: {driver_idx: fair_prob}}}.
+    """
+    return {
+        event: _process_one_event(event_odds, name_map, devig_method)
+        for event, event_odds in raw_odds.items()
+    }
+
+
 def get_observed_probs(
     roster: List[dict],
     name_map: Dict[str, int],
@@ -647,23 +704,25 @@ def get_observed_probs(
     debug_dir: Optional[str] = None,
 ) -> tuple:
     """
-    Main entry point: get observed probabilities keyed by roster index.
+    Main entry point: get event-keyed observed probabilities.
 
     Priority:
     1. If `scrape` is True, attempt to fetch fresh odds from Oddschecker.
-    2. Merge with manual file if provided (manual overrides scrape per-market).
+    2. Merge with manual file if provided (manual overrides scrape per-market,
+       per-event).
     3. Fall back to manual file alone if scraping is disabled or yields nothing.
 
     Returns
     -------
     (observed_probs, race_info, raw_odds)
-        observed_probs : {market: {driver_idx: fair_probability}}
+        observed_probs : {event: {market: {driver_idx: fair_probability}}}
+            event ∈ {"race", "sprint"}; "sprint" only present on sprint
+            weekends with sprint-specific odds.
         race_info : {race, date, is_sprint}
-        raw_odds : {market: {driver_name: american_odds}} — pre-devig snapshot
-            (post merge of scrape + manual). Saved to meta.raw_odds so future
-            audits can tell scraper / devig / model failures apart (issue #36).
+        raw_odds : {event: {market: {driver_name: american_odds}}} — pre-devig
+            snapshot (post merge of scrape + manual). Saved to meta.raw_odds.
     """
-    raw_odds: Dict[str, Dict[str, float]] = {}
+    raw_odds: Dict[str, Dict[str, Dict[str, float]]] = {}
     race_info = {"race": "Unknown", "date": "", "is_sprint": False}
 
     # Attempt scrape
@@ -677,18 +736,35 @@ def get_observed_probs(
         if scraped_odds:
             raw_odds.update(scraped_odds)
             race_info = scraped_info
-            print(f"  Scraped markets: {list(scraped_odds.keys())}")
+            print(f"  Scraped events: {list(scraped_odds.keys())}")
+            for event, markets in scraped_odds.items():
+                print(f"    {event}: {list(markets.keys())}")
 
-    # Load manual file (supplements or overrides scraped)
+    # Load manual file (supplements or overrides scraped per event/market).
     if manual_file and os.path.exists(manual_file):
         print(f"\nLoading manual odds from {manual_file}")
         data = load_manual_odds(manual_file)
-        for market, odds in data.get("markets", {}).items():
-            if market in raw_odds:
-                print(f"  Manual overrides scraped for: {market}")
-            else:
-                print(f"  Manual adds: {market}")
-            raw_odds[market] = odds
+
+        # Three accepted shapes (in priority order):
+        #   markets_race / markets_sprint  → explicit per-event sections
+        #   markets                        → race-only (legacy)
+        manual_events: Dict[str, Dict[str, Dict[str, float]]] = {}
+        if "markets_race" in data or "markets_sprint" in data:
+            if "markets_race" in data:
+                manual_events["race"] = data["markets_race"]
+            if "markets_sprint" in data:
+                manual_events["sprint"] = data["markets_sprint"]
+        elif "markets" in data:
+            manual_events["race"] = data["markets"]
+
+        for event, event_markets in manual_events.items():
+            event_bucket = raw_odds.setdefault(event, {})
+            for market, odds in event_markets.items():
+                if market in event_bucket:
+                    print(f"  Manual overrides scraped for: {event}/{market}")
+                else:
+                    print(f"  Manual adds: {event}/{market}")
+                event_bucket[market] = odds
 
         if race_info["race"] == "Unknown":
             race_info = {
@@ -702,11 +778,13 @@ def get_observed_probs(
 
     observed_probs = process_odds_to_fair_probs(raw_odds, name_map, devig_method)
 
-    print(f"\nFinal markets: {list(observed_probs.keys())}")
-    for market, probs in observed_probs.items():
-        n = len(probs)
-        top = sorted(probs.items(), key=lambda x: -x[1])[:3]
-        top_str = ", ".join(f"{roster[i]['abbr']}={p:.3f}" for i, p in top)
-        print(f"  {market} ({n} drivers): {top_str}")
+    print(f"\nFinal events: {list(observed_probs.keys())}")
+    for event, event_probs in observed_probs.items():
+        print(f"\n  [{event}] markets: {list(event_probs.keys())}")
+        for market, probs in event_probs.items():
+            n = len(probs)
+            top = sorted(probs.items(), key=lambda x: -x[1])[:3]
+            top_str = ", ".join(f"{roster[i]['abbr']}={p:.3f}" for i, p in top)
+            print(f"    {market} ({n} drivers): {top_str}")
 
     return observed_probs, race_info, raw_odds

--- a/pipeline/plackett_luce.py
+++ b/pipeline/plackett_luce.py
@@ -14,7 +14,7 @@ import numpy as np
 from itertools import combinations, permutations
 from scipy.optimize import minimize, linear_sum_assignment
 from typing import Dict, List, Tuple, Optional
-from config import RACE_POINTS, SPRINT_POINTS, DNF_PENALTY, CORRELATION_DEFAULTS
+from config import RACE_POINTS, SPRINT_POINTS, DNF_PENALTY, EXACT_BONUS, CORRELATION_DEFAULTS
 
 
 def simulate_races(
@@ -786,6 +786,144 @@ def fit_plackett_luce(
     return log_lambdas, p_dnfs, fit_info
 
 
+def simulate_event_metrics(
+    log_lambdas: np.ndarray,
+    p_dnfs: np.ndarray,
+    points_table: Dict[int, int],
+    n_sims: int = 50000,
+    seed: int = 12345,
+    team_indices: np.ndarray = None,
+    correlation: dict = None,
+    sigma_drv: np.ndarray = None,
+    chaos_alpha_drv: np.ndarray = None,
+) -> dict:
+    """
+    Run one event's worth of simulations and return per-driver metrics.
+
+    Returns a dict with parallel arrays indexed by driver:
+      pos_probs      : (n_drivers, n_drivers + 1) full position distribution
+      ep             : (n_drivers,) expected points under this event's table
+      std_dev        : (n_drivers,) std dev of points
+      p_win, p_podium, p_top6, p_top10, p_no_points : (n_drivers,) summaries
+
+    The event-agnostic split exists so race and sprint can each have their
+    own PL fit + simulation on sprint weekends.
+    """
+    pos_probs = simulate_races(
+        log_lambdas, p_dnfs, n_sims=n_sims, seed=seed,
+        team_indices=team_indices, correlation=correlation,
+        sigma_drv=sigma_drv,
+        chaos_alpha_drv=chaos_alpha_drv,
+    )
+
+    n = len(log_lambdas)
+    ep = np.zeros(n)
+    std_dev = np.zeros(n)
+    for i in range(n):
+        dist = pos_probs[i]
+        ep[i] = compute_expected_points(dist, points_table)
+        std_dev[i] = np.sqrt(compute_variance(dist, points_table))
+
+    p_win = pos_probs[:, 0]
+    p_podium = pos_probs[:, :3].sum(axis=1)
+    p_top6 = pos_probs[:, :6].sum(axis=1)
+    p_top10 = pos_probs[:, :10].sum(axis=1)
+    p_no_points = 1.0 - p_top10 - pos_probs[:, -1]
+
+    return {
+        "pos_probs": pos_probs,
+        "ep": ep,
+        "std_dev": std_dev,
+        "p_win": p_win,
+        "p_podium": p_podium,
+        "p_top6": p_top6,
+        "p_top10": p_top10,
+        "p_no_points": p_no_points,
+    }
+
+
+def assemble_driver_records(
+    drivers: List[dict],
+    race_metrics: dict,
+    race_log_lambdas: np.ndarray,
+    race_p_dnfs: np.ndarray,
+    race_sigma_drv: np.ndarray = None,
+    race_chaos_alpha_drv: np.ndarray = None,
+    sprint_metrics: dict = None,
+    sprint_log_lambdas: np.ndarray = None,
+    sprint_p_dnfs: np.ndarray = None,
+    sprint_sigma_drv: np.ndarray = None,
+    sprint_chaos_alpha_drv: np.ndarray = None,
+) -> List[dict]:
+    """
+    Combine race + (optional) sprint event metrics into per-driver output records.
+
+    For sprint weekends, sprint_metrics + sprint_log_lambdas come from a
+    separate PL fit on sprint odds; ep_sprint and the *_sprint stats reflect
+    the sprint-specific model. For non-sprint weekends, pass sprint_metrics=None.
+
+    The race-fit fields keep their unsuffixed names (lambda, p_dnf,
+    position_distribution, p_win, ...) for backward compat with the
+    Methodology page and any existing dashboard code. Sprint-fit fields
+    get the _sprint suffix.
+    """
+    n = len(drivers)
+    drivers_output = []
+
+    for i in range(n):
+        race_dist = race_metrics["pos_probs"][i]
+        ep_race = float(race_metrics["ep"][i])
+
+        if sprint_metrics is not None:
+            ep_sprint = float(sprint_metrics["ep"][i])
+        else:
+            ep_sprint = 0.0
+        ep_total = ep_race + ep_sprint
+
+        rec = {
+            "name": drivers[i]["name"],
+            "abbr": drivers[i]["abbr"],
+            "team_idx": drivers[i]["team_idx"],
+            "lambda": float(race_log_lambdas[i]),
+            "sigma_drv": float(race_sigma_drv[i]) if race_sigma_drv is not None else 1.0,
+            "chaos_alpha": float(race_chaos_alpha_drv[i]) if race_chaos_alpha_drv is not None else None,
+            "p_dnf": float(race_p_dnfs[i]),
+            "ep_race": round(ep_race, 2),
+            "ep_sprint": round(ep_sprint, 2),
+            "ep_total": round(ep_total, 2),
+            "std_dev": round(float(race_metrics["std_dev"][i]), 2),
+            "p_win": round(float(race_metrics["p_win"][i]), 4),
+            "p_podium": round(float(race_metrics["p_podium"][i]), 4),
+            "p_top6": round(float(race_metrics["p_top6"][i]), 4),
+            "p_top10": round(float(race_metrics["p_top10"][i]), 4),
+            "p_no_points": round(float(race_metrics["p_no_points"][i]), 4),
+            "position_distribution": [round(float(race_dist[k]), 5) for k in range(len(race_dist))],
+        }
+
+        if sprint_metrics is not None:
+            sprint_dist = sprint_metrics["pos_probs"][i]
+            rec.update({
+                "lambda_sprint": float(sprint_log_lambdas[i]) if sprint_log_lambdas is not None else None,
+                "sigma_drv_sprint": float(sprint_sigma_drv[i]) if sprint_sigma_drv is not None else 1.0,
+                "chaos_alpha_sprint": float(sprint_chaos_alpha_drv[i]) if sprint_chaos_alpha_drv is not None else None,
+                "p_dnf_sprint": float(sprint_p_dnfs[i]),
+                "std_dev_sprint": round(float(sprint_metrics["std_dev"][i]), 2),
+                "p_win_sprint": round(float(sprint_metrics["p_win"][i]), 4),
+                "p_podium_sprint": round(float(sprint_metrics["p_podium"][i]), 4),
+                "p_top6_sprint": round(float(sprint_metrics["p_top6"][i]), 4),
+                "p_top10_sprint": round(float(sprint_metrics["p_top10"][i]), 4),
+                "p_no_points_sprint": round(float(sprint_metrics["p_no_points"][i]), 4),
+                "position_distribution_sprint": [
+                    round(float(sprint_dist[k]), 5) for k in range(len(sprint_dist))
+                ],
+            })
+
+        drivers_output.append(rec)
+
+    drivers_output.sort(key=lambda d: -d["ep_total"])
+    return drivers_output
+
+
 def generate_full_output(
     log_lambdas: np.ndarray,
     p_dnfs: np.ndarray,
@@ -798,70 +936,58 @@ def generate_full_output(
     chaos_alpha_drv: np.ndarray = None,
 ) -> List[dict]:
     """
-    Generate the complete output for all drivers.
+    Backward-compatible single-fit driver output.
 
-    `drivers` is the active roster (from roster.fetch_current_roster). Each
-    entry must have name/abbr/team_idx fields. The output preserves these
-    plus the model's computed statistics, ready to be serialized to JSON.
+    Used when only a race PL fit exists (every non-sprint weekend, or when
+    sprint odds aren't available). For sprint weekends with dual fits, call
+    simulate_event_metrics + assemble_driver_records directly.
     """
-    pos_probs = simulate_races(
-        log_lambdas, p_dnfs, n_sims=n_sims, seed=12345,
-        team_indices=team_indices, correlation=correlation,
-        sigma_drv=sigma_drv,
-        chaos_alpha_drv=chaos_alpha_drv,
+    race_metrics = simulate_event_metrics(
+        log_lambdas, p_dnfs, RACE_POINTS,
+        n_sims=n_sims, team_indices=team_indices, correlation=correlation,
+        sigma_drv=sigma_drv, chaos_alpha_drv=chaos_alpha_drv,
     )
-
-    drivers_output = []
-    for i in range(len(log_lambdas)):
-        dist = pos_probs[i]
-        ep_race = compute_expected_points(dist, RACE_POINTS)
-        ep_sprint = compute_expected_points(dist, SPRINT_POINTS) if is_sprint else 0.0
-        ep_total = ep_race + ep_sprint
-
-        var_race = compute_variance(dist, RACE_POINTS)
-        std_race = np.sqrt(var_race)
-
-        # Key probabilities
-        p_win = float(dist[0])
-        p_podium = float(dist[:3].sum())
-        p_top6 = float(dist[:6].sum())
-        p_top10 = float(dist[:10].sum())
-        p_no_points = float(1.0 - p_top10 - dist[-1])
-
-        driver_info = drivers[i]
-
-        drivers_output.append({
-            "name": driver_info["name"],
-            "abbr": driver_info["abbr"],
-            "team_idx": driver_info["team_idx"],
-            "lambda": float(log_lambdas[i]),
-            "sigma_drv": float(sigma_drv[i]) if sigma_drv is not None else 1.0,
-            "chaos_alpha": float(chaos_alpha_drv[i]) if chaos_alpha_drv is not None else None,
-            "p_dnf": float(p_dnfs[i]),
-            "ep_race": round(ep_race, 2),
-            "ep_sprint": round(ep_sprint, 2),
-            "ep_total": round(ep_total, 2),
-            "std_dev": round(std_race, 2),
-            "p_win": round(p_win, 4),
-            "p_podium": round(p_podium, 4),
-            "p_top6": round(p_top6, 4),
-            "p_top10": round(p_top10, 4),
-            "p_no_points": round(p_no_points, 4),
-            # Full distribution (for charts)
-            "position_distribution": [round(float(dist[k]), 5) for k in range(len(dist))],
-        })
-
-    # Sort by expected total points
-    drivers_output.sort(key=lambda d: -d["ep_total"])
-
-    return drivers_output
+    if is_sprint:
+        # Single-fit sprint path: reuse the race PL distribution to score sprint
+        # points (legacy behavior — only correct when no separate sprint odds).
+        sprint_metrics = {
+            "pos_probs": race_metrics["pos_probs"],
+            "ep": np.array([
+                compute_expected_points(race_metrics["pos_probs"][i], SPRINT_POINTS)
+                for i in range(len(log_lambdas))
+            ]),
+            "std_dev": np.zeros(len(log_lambdas)),
+            "p_win": race_metrics["p_win"],
+            "p_podium": race_metrics["p_podium"],
+            "p_top6": race_metrics["p_top6"],
+            "p_top10": race_metrics["p_top10"],
+            "p_no_points": race_metrics["p_no_points"],
+        }
+        # Compute sprint std_dev from the same distribution but sprint scoring
+        for i in range(len(log_lambdas)):
+            sprint_metrics["std_dev"][i] = np.sqrt(
+                compute_variance(race_metrics["pos_probs"][i], SPRINT_POINTS)
+            )
+        return assemble_driver_records(
+            drivers, race_metrics, log_lambdas, p_dnfs,
+            race_sigma_drv=sigma_drv, race_chaos_alpha_drv=chaos_alpha_drv,
+            sprint_metrics=sprint_metrics,
+            sprint_log_lambdas=log_lambdas, sprint_p_dnfs=p_dnfs,
+            sprint_sigma_drv=sigma_drv, sprint_chaos_alpha_drv=chaos_alpha_drv,
+        )
+    return assemble_driver_records(
+        drivers, race_metrics, log_lambdas, p_dnfs,
+        race_sigma_drv=sigma_drv, race_chaos_alpha_drv=chaos_alpha_drv,
+    )
 
 
 def find_top_lineups(
     drivers_data: List[dict],
     n_picks: int = 5,
-    exact_pos_bonus: float = 10.0,
+    exact_pos_bonus: float = EXACT_BONUS,
     top_n: int = 10,
+    score_key: str = "ep_total",
+    dist_keys: Tuple[str, ...] = ("position_distribution",),
 ) -> List[dict]:
     """
     Find the top_n highest-scoring ordered lineups by expected points
@@ -876,19 +1002,20 @@ def find_top_lineups(
     At 22 drivers / 5 picks: C(22,5)=26,334 selections × 5!=120 permutations.
     The inner product is computed entirely in numpy with no Python inner loop.
 
-    Score matrix identity
-    ---------------------
-    total[combo, perm] = Σ_i  ep_base[combo[i]] + pos_bonus[combo[i], perm[i]]
-                       = ep_base_sum[combo]  +  Σ_i B[combo, i, perm[i]]
-
-    where B[c,i,s] = pos_bonus[combo_c_driver_i, slot_s].
-
     Parameters
     ----------
     drivers_data : list of driver dicts from generate_full_output
     n_picks : number of picks (default 5)
-    exact_pos_bonus : bonus for exact position match (default 10)
+    exact_pos_bonus : bonus for exact position match (default EXACT_BONUS)
     top_n : number of lineups to return (default 10)
+    score_key : driver-dict key for the per-driver base ep used in lineup scoring
+        (e.g. "ep_total" for combined, "ep_race", "ep_sprint")
+    dist_keys : tuple of driver-dict keys whose position distributions are
+        SUMMED to compute the slot bonus. The slot bonus represents
+        P(driver finishes pos = slot) summed across applicable events. Use
+        ("position_distribution",) for race-only or single-fit weekends, or
+        ("position_distribution", "position_distribution_sprint") for the
+        combined race+sprint lineup on dual-fit sprint weekends.
 
     Returns
     -------
@@ -896,13 +1023,16 @@ def find_top_lineups(
         rank, picks, ep_base_total, ep_bonus_total, ep_grand_total
     """
     n = len(drivers_data)
-    ep_totals = np.array([d["ep_total"] for d in drivers_data])
+    ep_totals = np.array([d[score_key] for d in drivers_data])
 
-    # pos_bonus[d, s] = P(driver d finishes position s+1) * exact_pos_bonus
-    pos_bonus = np.array([
-        [d["position_distribution"][s] * exact_pos_bonus for s in range(n_picks)]
-        for d in drivers_data
-    ])  # (n_drivers, n_picks)
+    # pos_bonus[d, s] = (Σ_event P(driver d finishes position s+1)) * exact_pos_bonus
+    pos_bonus = np.zeros((n, n_picks))
+    for dk in dist_keys:
+        pos_bonus += np.array([
+            [d[dk][s] for s in range(n_picks)]
+            for d in drivers_data
+        ])
+    pos_bonus *= exact_pos_bonus
 
     # All C(n, n_picks) driver-index combinations: shape (n_combos, n_picks)
     all_combos = np.array(list(combinations(range(n), n_picks)))  # (26334, 5)

--- a/pipeline/tests/test_odds_fetcher.py
+++ b/pipeline/tests/test_odds_fetcher.py
@@ -100,65 +100,90 @@ class TestLoadManualOdds:
 
 
 class TestProcessOddsToFairProbs:
+    """`process_odds_to_fair_probs` takes event-keyed input
+    `{event: {market: {driver: odds}}}` and returns the same shape with fair
+    probabilities. Tests wrap their single-event fixtures under a "race" key.
+    """
+
     @pytest.fixture
     def win_odds(self):
         return {
-            "win": {
-                "Russell": -150,
-                "Antonelli": 200,
-                "Leclerc": 600,
-                "Hamilton": 800,
+            "race": {
+                "win": {
+                    "Russell": -150,
+                    "Antonelli": 200,
+                    "Leclerc": 600,
+                    "Hamilton": 800,
+                }
             }
         }
 
     def test_win_market_sums_to_one(self, win_odds, name_map):
         result = process_odds_to_fair_probs(win_odds, name_map)
-        probs = result["win"]
+        probs = result["race"]["win"]
         assert sum(probs.values()) == pytest.approx(1.0, abs=1e-4)
 
     def test_win_market_uses_driver_indices(self, win_odds, name_map):
         result = process_odds_to_fair_probs(win_odds, name_map)
         # Russell is roster index 0
-        assert 0 in result["win"]
+        assert 0 in result["race"]["win"]
 
     def test_win_favorite_has_highest_prob(self, win_odds, name_map):
         result = process_odds_to_fair_probs(win_odds, name_map)
-        probs = result["win"]
+        probs = result["race"]["win"]
         assert probs[0] == max(probs.values())
 
     def test_placement_market(self, name_map):
         raw = {
-            "podium": {
-                "Russell": -300,
-                "Antonelli": -200,
-                "Leclerc": 120,
-                "Hamilton": 150,
+            "race": {
+                "podium": {
+                    "Russell": -300,
+                    "Antonelli": -200,
+                    "Leclerc": 120,
+                    "Hamilton": 150,
+                }
             }
         }
         result = process_odds_to_fair_probs(raw, name_map)
-        probs = result["podium"]
+        probs = result["race"]["podium"]
         # Podium probs should sum to ~3 (3 podium slots), modulo small overround
         assert sum(probs.values()) == pytest.approx(3.0, abs=0.5)
 
     def test_dnf_market(self, name_map):
         raw = {
-            "dnf": {
-                "Russell": 1200,   # low DNF chance
-                "Verstappen": 500, # higher DNF chance
+            "race": {
+                "dnf": {
+                    "Russell": 1200,   # low DNF chance
+                    "Verstappen": 500, # higher DNF chance
+                }
             }
         }
         result = process_odds_to_fair_probs(raw, name_map)
-        dnf = result["dnf"]
+        dnf = result["race"]["dnf"]
         ver_idx = resolve_driver_index("Verstappen", name_map)
         rus_idx = resolve_driver_index("Russell", name_map)
         assert dnf[ver_idx] > dnf[rus_idx]
 
     def test_unknown_driver_skipped(self, name_map):
-        raw = {"win": {"Russell": -150, "UnknownDriver": 5000}}
+        raw = {"race": {"win": {"Russell": -150, "UnknownDriver": 5000}}}
         result = process_odds_to_fair_probs(raw, name_map)
-        assert 0 in result["win"]
-        assert len(result["win"]) == 1
+        assert 0 in result["race"]["win"]
+        assert len(result["race"]["win"]) == 1
 
     def test_empty_market_skipped(self, name_map):
-        result = process_odds_to_fair_probs({"win": {}}, name_map)
-        assert "win" not in result
+        result = process_odds_to_fair_probs({"race": {"win": {}}}, name_map)
+        assert "win" not in result["race"]
+
+    def test_dual_event_sprint_weekend(self, name_map):
+        """Sprint weekend: both race and sprint events get devigged independently."""
+        raw = {
+            "race": {"win": {"Russell": -150, "Antonelli": 200, "Leclerc": 600, "Hamilton": 800}},
+            "sprint": {"win": {"Antonelli": 165, "Russell": 250, "Leclerc": 500, "Hamilton": 700}},
+        }
+        result = process_odds_to_fair_probs(raw, name_map)
+        assert "race" in result and "sprint" in result
+        assert sum(result["race"]["win"].values()) == pytest.approx(1.0, abs=1e-4)
+        assert sum(result["sprint"]["win"].values()) == pytest.approx(1.0, abs=1e-4)
+        # Sprint favorite is Antonelli (index 1), race favorite is Russell (index 0)
+        assert max(result["race"]["win"], key=result["race"]["win"].get) == 0
+        assert max(result["sprint"]["win"], key=result["sprint"]["win"].get) == 1

--- a/pipeline/update.py
+++ b/pipeline/update.py
@@ -26,7 +26,7 @@ import numpy as np
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from config import (
-    RACE_POINTS, SPRINT_POINTS, DNF_PENALTY,
+    RACE_POINTS, SPRINT_POINTS, DNF_PENALTY, EXACT_BONUS,
     SPRINT_WEEKENDS, CORRELATION_DEFAULTS,
 )
 from roster import fetch_current_roster, teams_from_roster, build_name_map
@@ -34,41 +34,24 @@ from odds_fetcher import get_observed_probs
 from plackett_luce import (
     fit_plackett_luce,
     generate_full_output,
+    simulate_event_metrics,
+    assemble_driver_records,
     find_top_lineups,
     simulate_races,
     compute_expected_points,
 )
 
 
-def build_output_json(
-    drivers_data: list,
-    teams: list,
-    roster: list,
-    race_info: dict,
-    fit_info: dict,
-    log_lambdas: np.ndarray,
-    p_dnfs: np.ndarray,
-    top_lineups: list = None,
-    observed_probs: dict = None,
-    n_final_sims: int = 50000,
-    devig_method: str = "shin",
-    run_type: str = "",
-    correlation: dict = None,
-    raw_odds: dict = None,
-) -> dict:
-    """Assemble the final JSON that the frontend reads."""
-    # Build market input summary (translate driver_idx → abbr via roster)
+def _fit_section(fit_info: dict, observed_event: dict, roster: list) -> dict:
+    """Build the JSON `fit` block for one event's PL fit."""
     market_inputs = []
-    if observed_probs:
-        for market, probs in observed_probs.items():
-            market_inputs.append({
-                "market": market,
-                "n_drivers": len(probs),
-                "drivers": [roster[i]["abbr"] for i in sorted(probs.keys())],
-            })
+    for market, probs in (observed_event or {}).items():
+        market_inputs.append({
+            "market": market,
+            "n_drivers": len(probs),
+            "drivers": [roster[i]["abbr"] for i in sorted(probs.keys())],
+        })
 
-    # Residuals from the fit reference driver_idx — annotate with the abbr now
-    # that we have a roster, so the frontend can render them readably.
     residuals = []
     for r in fit_info.get("residuals", []):
         idx = r.get("driver_idx")
@@ -76,6 +59,56 @@ def build_output_json(
             **r,
             "driver": roster[idx]["abbr"] if idx is not None and 0 <= idx < len(roster) else "?",
         })
+
+    return {
+        "method": fit_info.get("method", "unknown"),
+        "converged": fit_info.get("success", None),
+        "final_loss": fit_info.get("loss", None),
+        "n_evals": fit_info.get("n_evals", None),
+        "n_steps": fit_info.get("n_steps", None),
+        "elapsed_seconds": fit_info.get("elapsed_seconds", None),
+        "n_sims_per_eval": fit_info.get("n_sims_per_eval", None),
+        "n_params": fit_info.get("n_params", None),
+        "team_reg": fit_info.get("team_reg", None),
+        "smoothness_reg": fit_info.get("smoothness_reg", None),
+        "sigma_drv_reg": fit_info.get("sigma_drv_reg", None),
+        "chaos_alpha_drv_reg": fit_info.get("chaos_alpha_drv_reg", None),
+        "fit_sigma_drv": fit_info.get("fit_sigma_drv", None),
+        "fit_chaos_alpha_drv": fit_info.get("fit_chaos_alpha_drv", None),
+        "market_weights": fit_info.get("market_weights", None),
+        "message": fit_info.get("message", ""),
+        "loss_history": fit_info.get("loss_history", []),
+        "step_losses": fit_info.get("step_losses", []),
+        "residuals": residuals,
+        "market_inputs": market_inputs,
+    }
+
+
+def build_output_json(
+    drivers_data: list,
+    teams: list,
+    roster: list,
+    race_info: dict,
+    race_fit_info: dict,
+    sprint_fit_info: dict = None,
+    top_lineups: list = None,
+    top_lineups_race: list = None,
+    top_lineups_sprint: list = None,
+    observed_probs: dict = None,
+    n_final_sims: int = 50000,
+    devig_method: str = "shin",
+    run_type: str = "",
+    correlation: dict = None,
+    raw_odds: dict = None,
+) -> dict:
+    """Assemble the final JSON that the frontend reads.
+
+    `observed_probs` is the event-keyed dict {event: {market: {idx: prob}}}.
+    `raw_odds` is also event-keyed, before devig.
+    """
+    has_sprint = sprint_fit_info is not None
+    obs_race = (observed_probs or {}).get("race", {})
+    obs_sprint = (observed_probs or {}).get("sprint", {})
 
     return {
         "meta": {
@@ -86,8 +119,10 @@ def build_output_json(
             "model": "plackett-luce",
             "n_simulations": n_final_sims,
             "devig_method": devig_method,
-            "fit_loss": fit_info.get("loss", None),
-            "fit_converged": fit_info.get("success", None),
+            "fit_loss": race_fit_info.get("loss", None),
+            "fit_converged": race_fit_info.get("success", None),
+            "fit_loss_sprint": (sprint_fit_info or {}).get("loss"),
+            "fit_converged_sprint": (sprint_fit_info or {}).get("success"),
             "run_type": run_type,
             "correlation": correlation,
             # Pre-devig snapshot of the odds that fed this run, keyed by the
@@ -100,31 +135,14 @@ def build_output_json(
             "race": RACE_POINTS,
             "sprint": SPRINT_POINTS,
             "dnf_penalty": DNF_PENALTY,
+            "exact_bonus": EXACT_BONUS,
         },
         "drivers": drivers_data,
         "top_lineups": top_lineups,
-        "fit": {
-            "method": fit_info.get("method", "unknown"),
-            "converged": fit_info.get("success", None),
-            "final_loss": fit_info.get("loss", None),
-            "n_evals": fit_info.get("n_evals", None),
-            "n_steps": fit_info.get("n_steps", None),
-            "elapsed_seconds": fit_info.get("elapsed_seconds", None),
-            "n_sims_per_eval": fit_info.get("n_sims_per_eval", None),
-            "n_params": fit_info.get("n_params", None),
-            "team_reg": fit_info.get("team_reg", None),
-            "smoothness_reg": fit_info.get("smoothness_reg", None),
-            "sigma_drv_reg": fit_info.get("sigma_drv_reg", None),
-            "chaos_alpha_drv_reg": fit_info.get("chaos_alpha_drv_reg", None),
-            "fit_sigma_drv": fit_info.get("fit_sigma_drv", None),
-            "fit_chaos_alpha_drv": fit_info.get("fit_chaos_alpha_drv", None),
-            "market_weights": fit_info.get("market_weights", None),
-            "message": fit_info.get("message", ""),
-            "loss_history": fit_info.get("loss_history", []),
-            "step_losses": fit_info.get("step_losses", []),
-            "residuals": residuals,
-            "market_inputs": market_inputs,
-        },
+        "top_lineups_race": top_lineups_race,
+        "top_lineups_sprint": top_lineups_sprint,
+        "fit": _fit_section(race_fit_info, obs_race, roster),
+        "fit_sprint": _fit_section(sprint_fit_info, obs_sprint, roster) if has_sprint else None,
     }
 
 
@@ -210,7 +228,7 @@ def run_pipeline(
     for d in roster:
         print(f"    {d['abbr']:4s} {d['name']:25s} → {d['team_name']}")
 
-    # Step 1: Get observed probabilities (keyed by roster index)
+    # Step 1: Get observed probabilities (event-keyed: {event: {market: {idx: prob}}})
     print("\n[1/4] Loading odds data...")
     observed_probs, race_info, raw_odds = get_observed_probs(
         roster=roster,
@@ -220,56 +238,91 @@ def run_pipeline(
         devig_method=devig_method,
     )
 
-    if not observed_probs:
-        print("ERROR: No odds data loaded. Exiting.")
+    if not observed_probs or "race" not in observed_probs:
+        print("ERROR: No race odds loaded. Exiting.")
         sys.exit(1)
 
-    # Check if sprint weekend
-    race_slug = race_info.get("race", "").lower().replace(" ", "-").replace("grand-prix", "gp")
-    if race_slug in SPRINT_WEEKENDS:
+    # Check if sprint weekend (schedule + observed odds both signal)
+    race_slug_for_sprint = race_info.get("race", "").lower().replace(" ", "-").replace("grand-prix", "gp")
+    if race_slug_for_sprint in SPRINT_WEEKENDS:
         race_info["is_sprint"] = True
-        print(f"  Sprint weekend detected: {race_info['race']}")
+    has_sprint_odds = "sprint" in observed_probs and observed_probs["sprint"]
+    if race_info.get("is_sprint") and has_sprint_odds:
+        print(f"  Sprint weekend detected with sprint odds: {race_info['race']}")
+    elif race_info.get("is_sprint"):
+        print(f"  Sprint weekend detected (no sprint-specific odds — sprint EP "
+              f"will reuse race PL fit)")
 
-    # Step 2: Fit the model
-    print("\n[2/4] Fitting Plackett-Luce model...")
+    # Step 2: Fit the model(s) — race always; sprint only if its own odds present.
     team_indices = np.array([d["team_idx"] for d in roster])
 
-    # If we only have win odds and no other markets, we can still fit
-    # (just fewer constraints, so regularization matters more)
-    n_markets = len(observed_probs)
-    n_constraints = sum(len(v) for v in observed_probs.values())
-    print(f"  {n_markets} markets, {n_constraints} total constraints")
+    def _fit_event(event_label, event_obs):
+        n_markets = len(event_obs)
+        n_constraints = sum(len(v) for v in event_obs.values())
+        print(f"\n[{event_label}] {n_markets} markets, {n_constraints} constraints")
+        if "dnf" not in event_obs:
+            print(f"  [{event_label}] No DNF odds available, using defaults (10% base)")
+            event_obs = {**event_obs, "dnf": {i: 0.10 for i in range(n_drivers)}}
+        ll, pdf, info = fit_plackett_luce(
+            observed_probs=event_obs,
+            team_indices=team_indices,
+            n_sims=n_fit_sims,
+            correlation=correlation,
+            fit_chaos_alpha_drv=fit_chaos_alpha_drv,
+        )
+        print(f"  [{event_label}] Fit complete. Loss: {info['loss']:.6f}")
+        return ll, pdf, info, event_obs
 
-    # Fill in missing DNF probs with defaults
-    if "dnf" not in observed_probs:
-        print("  No DNF odds available, using defaults (10% base)")
-        observed_probs["dnf"] = {i: 0.10 for i in range(n_drivers)}
+    print("\n[2/4] Fitting Plackett-Luce model(s)...")
+    race_ll, race_pdf, race_fit, observed_probs["race"] = _fit_event("race", observed_probs["race"])
 
-    log_lambdas, p_dnfs, fit_info = fit_plackett_luce(
-        observed_probs=observed_probs,
-        team_indices=team_indices,
-        n_sims=n_fit_sims,
-        correlation=correlation,
-        fit_chaos_alpha_drv=fit_chaos_alpha_drv,
+    sprint_ll = sprint_pdf = sprint_fit = None
+    if has_sprint_odds:
+        sprint_ll, sprint_pdf, sprint_fit, observed_probs["sprint"] = _fit_event(
+            "sprint", observed_probs["sprint"]
+        )
+
+    # Step 3: Run final simulation per event.
+    print("\n[3/4] Running final simulation (50K races) per event...")
+
+    race_sigma_drv = np.array(race_fit["sigma_drv"]) if race_fit.get("sigma_drv") else None
+    race_chaos_alpha = (np.array(race_fit["chaos_alpha_drv"])
+                        if race_fit.get("chaos_alpha_drv") else None)
+    race_metrics = simulate_event_metrics(
+        race_ll, race_pdf, RACE_POINTS,
+        n_sims=n_final_sims, team_indices=team_indices, correlation=correlation,
+        sigma_drv=race_sigma_drv, chaos_alpha_drv=race_chaos_alpha,
     )
 
-    print(f"\n  Fit complete. Loss: {fit_info['loss']:.6f}")
+    sprint_metrics = None
+    sprint_sigma_drv = sprint_chaos_alpha = None
+    if sprint_fit is not None:
+        sprint_sigma_drv = np.array(sprint_fit["sigma_drv"]) if sprint_fit.get("sigma_drv") else None
+        sprint_chaos_alpha = (np.array(sprint_fit["chaos_alpha_drv"])
+                              if sprint_fit.get("chaos_alpha_drv") else None)
+        sprint_metrics = simulate_event_metrics(
+            sprint_ll, sprint_pdf, SPRINT_POINTS,
+            n_sims=n_final_sims, team_indices=team_indices, correlation=correlation,
+            sigma_drv=sprint_sigma_drv, chaos_alpha_drv=sprint_chaos_alpha,
+        )
+    elif race_info.get("is_sprint"):
+        # Single-fit fallback: reuse race PL distribution scored with sprint table.
+        sprint_metrics = simulate_event_metrics(
+            race_ll, race_pdf, SPRINT_POINTS,
+            n_sims=n_final_sims, team_indices=team_indices, correlation=correlation,
+            sigma_drv=race_sigma_drv, chaos_alpha_drv=race_chaos_alpha,
+            seed=12346,
+        )
 
-    # Step 3: Generate full simulation output
-    print("\n[3/4] Running final simulation (50K races)...")
-    sigma_drv = np.array(fit_info["sigma_drv"]) if fit_info.get("sigma_drv") else None
-    chaos_alpha_drv = (np.array(fit_info["chaos_alpha_drv"])
-                       if fit_info.get("chaos_alpha_drv") else None)
-    drivers_data = generate_full_output(
-        log_lambdas,
-        p_dnfs,
+    drivers_data = assemble_driver_records(
         roster,
-        is_sprint=race_info.get("is_sprint", False),
-        n_sims=n_final_sims,
-        team_indices=team_indices,
-        correlation=correlation,
-        sigma_drv=sigma_drv,
-        chaos_alpha_drv=chaos_alpha_drv,
+        race_metrics, race_ll, race_pdf,
+        race_sigma_drv=race_sigma_drv, race_chaos_alpha_drv=race_chaos_alpha,
+        sprint_metrics=sprint_metrics,
+        sprint_log_lambdas=(sprint_ll if sprint_ll is not None else (race_ll if sprint_metrics is not None else None)),
+        sprint_p_dnfs=(sprint_pdf if sprint_pdf is not None else (race_pdf if sprint_metrics is not None else None)),
+        sprint_sigma_drv=sprint_sigma_drv if sprint_fit is not None else (race_sigma_drv if sprint_metrics is not None else None),
+        sprint_chaos_alpha_drv=sprint_chaos_alpha if sprint_fit is not None else (race_chaos_alpha if sprint_metrics is not None else None),
     )
 
     # Print summary
@@ -279,12 +332,41 @@ def run_pipeline(
     for rank, d in enumerate(drivers_data[:10], 1):
         print(f"  {rank:4d} {d['name']:20s} {d['ep_race']:8.2f} {d['ep_sprint']:9.2f} {d['ep_total']:8.2f} {d['std_dev']:6.1f} {d['p_win']:7.3f} {d['p_dnf']:7.3f}")
 
-    # Step 3b: Find top lineups
+    # Step 3b: Find top lineups (combined; race-only and sprint-only on sprint weekends)
     print("\n[3b/4] Finding top 10 lineups...")
-    top_lineups = find_top_lineups(drivers_data, top_n=10)
+    has_dual_distributions = sprint_metrics is not None and any(
+        "position_distribution_sprint" in d for d in drivers_data
+    )
+    combined_dist_keys = (
+        ("position_distribution", "position_distribution_sprint")
+        if has_dual_distributions else ("position_distribution",)
+    )
+    top_lineups = find_top_lineups(
+        drivers_data, top_n=10,
+        score_key="ep_total", dist_keys=combined_dist_keys,
+    )
     for lineup in top_lineups[:3]:
         abbrs = " ".join(f"{p['abbr']}→P{p['slot']}" for p in lineup["picks"])
-        print(f"  #{lineup['rank']}: {abbrs}  →  {lineup['ep_grand_total']:.2f} E[pts]")
+        print(f"  Combined  #{lineup['rank']}: {abbrs}  →  {lineup['ep_grand_total']:.2f} E[pts]")
+
+    top_lineups_race = None
+    top_lineups_sprint = None
+    if sprint_metrics is not None:
+        top_lineups_race = find_top_lineups(
+            drivers_data, top_n=10,
+            score_key="ep_race", dist_keys=("position_distribution",),
+        )
+        for lineup in top_lineups_race[:3]:
+            abbrs = " ".join(f"{p['abbr']}→P{p['slot']}" for p in lineup["picks"])
+            print(f"  Race-only #{lineup['rank']}: {abbrs}  →  {lineup['ep_grand_total']:.2f} E[pts]")
+        if has_dual_distributions:
+            top_lineups_sprint = find_top_lineups(
+                drivers_data, top_n=10,
+                score_key="ep_sprint", dist_keys=("position_distribution_sprint",),
+            )
+            for lineup in top_lineups_sprint[:3]:
+                abbrs = " ".join(f"{p['abbr']}→P{p['slot']}" for p in lineup["picks"])
+                print(f"  Sprint    #{lineup['rank']}: {abbrs}  →  {lineup['ep_grand_total']:.2f} E[pts]")
 
     # Step 4: Write output
     print("\n[4/4] Writing output files...")
@@ -293,8 +375,12 @@ def run_pipeline(
     (output_dir / "races").mkdir(exist_ok=True)
 
     output = build_output_json(
-        drivers_data, teams, roster, race_info, fit_info, log_lambdas, p_dnfs,
+        drivers_data, teams, roster, race_info,
+        race_fit_info=race_fit,
+        sprint_fit_info=sprint_fit,
         top_lineups=top_lineups,
+        top_lineups_race=top_lineups_race,
+        top_lineups_sprint=top_lineups_sprint,
         observed_probs=observed_probs,
         n_final_sims=n_final_sims,
         devig_method=devig_method,
@@ -444,14 +530,17 @@ def main():
         print(f"Race:    {race_info.get('race', '?')}")
         print(f"Date:    {race_info.get('date', '?')}")
         print(f"Sprint:  {race_info.get('is_sprint', False)}")
-        print(f"Markets: {list(observed_probs.keys())}")
+        print(f"Events:  {list(observed_probs.keys())}")
 
-        for market, probs in observed_probs.items():
-            print(f"\n[{market}] {len(probs)} drivers — fair probabilities (devigged):")
-            ranked = sorted(probs.items(), key=lambda x: -x[1])
-            for idx, p in ranked:
-                d = roster[idx]
-                print(f"  {d['abbr']:5s} {d['name']:25s} p={p:.4f}")
+        for event, event_markets in observed_probs.items():
+            print(f"\n=== EVENT: {event} ===")
+            print(f"Markets: {list(event_markets.keys())}")
+            for market, probs in event_markets.items():
+                print(f"\n[{event}/{market}] {len(probs)} drivers — fair probabilities (devigged):")
+                ranked = sorted(probs.items(), key=lambda x: -x[1])
+                for idx, p in ranked:
+                    d = roster[idx]
+                    print(f"  {d['abbr']:5s} {d['name']:25s} p={p:.4f}")
 
         print("\nDry run complete — no files written.")
         return

--- a/public/data/latest.json
+++ b/public/data/latest.json
@@ -117,7 +117,9 @@
         "Sergio Perez": 10000.0,
         "Valtteri Bottas": 10000.0
       }
-    }
+    },
+    "backfilled_at": "2026-05-02T18:44:13.755611+00:00",
+    "backfill_note": "DNF penalty corrected from -20 to -10; per-driver EPs and lineups recomputed from existing position_distribution arrays."
   },
   "teams": [
     {
@@ -199,7 +201,8 @@
       "7": 2,
       "8": 1
     },
-    "dnf_penalty": -20
+    "dnf_penalty": -10,
+    "exact_bonus": 10
   },
   "drivers": [
     {
@@ -210,10 +213,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 12.16,
-      "ep_sprint": 2.88,
-      "ep_total": 15.04,
-      "std_dev": 13.83,
+      "ep_race": 13.21,
+      "ep_sprint": 3.93,
+      "ep_total": 17.15,
+      "std_dev": 11.52,
       "p_win": 0.3254,
       "p_podium": 0.5955,
       "p_top6": 0.7207,
@@ -253,10 +256,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 11.27,
-      "ep_sprint": 2.67,
-      "ep_total": 13.94,
-      "std_dev": 13.39,
+      "ep_race": 12.31,
+      "ep_sprint": 3.71,
+      "ep_total": 16.02,
+      "std_dev": 11.12,
       "p_win": 0.2545,
       "p_podium": 0.5576,
       "p_top6": 0.7072,
@@ -296,10 +299,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 7.97,
-      "ep_sprint": 1.61,
-      "ep_total": 9.58,
-      "std_dev": 12.18,
+      "ep_race": 9.03,
+      "ep_sprint": 2.68,
+      "ep_total": 11.71,
+      "std_dev": 9.92,
       "p_win": 0.1072,
       "p_podium": 0.3726,
       "p_top6": 0.6187,
@@ -339,10 +342,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 7.33,
-      "ep_sprint": 1.4,
-      "ep_total": 8.74,
-      "std_dev": 11.86,
+      "ep_race": 8.39,
+      "ep_sprint": 2.46,
+      "ep_total": 10.84,
+      "std_dev": 9.62,
       "p_win": 0.0881,
       "p_podium": 0.3299,
       "p_top6": 0.5935,
@@ -382,10 +385,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 6.79,
-      "ep_sprint": 1.21,
-      "ep_total": 8.0,
-      "std_dev": 11.6,
+      "ep_race": 7.84,
+      "ep_sprint": 2.26,
+      "ep_total": 10.1,
+      "std_dev": 9.36,
       "p_win": 0.0727,
       "p_podium": 0.2964,
       "p_top6": 0.5688,
@@ -425,10 +428,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 5.54,
-      "ep_sprint": 0.7,
-      "ep_total": 6.24,
-      "std_dev": 11.16,
+      "ep_race": 6.63,
+      "ep_sprint": 1.79,
+      "ep_total": 8.42,
+      "std_dev": 8.86,
       "p_win": 0.0486,
       "p_podium": 0.2259,
       "p_top6": 0.5108,
@@ -468,10 +471,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 4.27,
-      "ep_sprint": 0.22,
-      "ep_total": 4.48,
-      "std_dev": 10.42,
+      "ep_race": 5.34,
+      "ep_sprint": 1.29,
+      "ep_total": 6.63,
+      "std_dev": 8.13,
       "p_win": 0.0296,
       "p_podium": 0.1541,
       "p_top6": 0.4311,
@@ -511,10 +514,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 3.86,
-      "ep_sprint": 0.07,
-      "ep_total": 3.93,
-      "std_dev": 10.14,
+      "ep_race": 4.92,
+      "ep_sprint": 1.13,
+      "ep_total": 6.05,
+      "std_dev": 7.84,
       "p_win": 0.0231,
       "p_podium": 0.1324,
       "p_top6": 0.4036,
@@ -554,10 +557,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 2.86,
-      "ep_sprint": -0.35,
-      "ep_total": 2.52,
-      "std_dev": 9.67,
+      "ep_race": 3.94,
+      "ep_sprint": 0.73,
+      "ep_total": 4.67,
+      "std_dev": 7.34,
       "p_win": 0.0156,
       "p_podium": 0.0946,
       "p_top6": 0.3304,
@@ -597,10 +600,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 2.69,
-      "ep_sprint": -0.4,
-      "ep_total": 2.29,
-      "std_dev": 9.49,
+      "ep_race": 3.75,
+      "ep_sprint": 0.66,
+      "ep_total": 4.41,
+      "std_dev": 7.18,
       "p_win": 0.0134,
       "p_podium": 0.0869,
       "p_top6": 0.3159,
@@ -640,10 +643,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 2.61,
-      "ep_sprint": -0.42,
-      "ep_total": 2.19,
-      "std_dev": 9.4,
+      "ep_race": 3.66,
+      "ep_sprint": 0.63,
+      "ep_total": 4.29,
+      "std_dev": 7.09,
       "p_win": 0.0124,
       "p_podium": 0.0819,
       "p_top6": 0.309,
@@ -683,10 +686,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 0.01,
-      "ep_sprint": -1.44,
-      "ep_total": -1.43,
-      "std_dev": 7.78,
+      "ep_race": 1.07,
+      "ep_sprint": -0.38,
+      "ep_total": 0.69,
+      "std_dev": 5.26,
       "p_win": 0.0024,
       "p_podium": 0.019,
       "p_top6": 0.1137,
@@ -726,10 +729,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -0.25,
-      "ep_sprint": -1.55,
-      "ep_total": -1.8,
-      "std_dev": 7.65,
+      "ep_race": 0.82,
+      "ep_sprint": -0.48,
+      "ep_total": 0.34,
+      "std_dev": 5.08,
       "p_win": 0.002,
       "p_podium": 0.0156,
       "p_top6": 0.0985,
@@ -769,10 +772,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -0.66,
-      "ep_sprint": -1.71,
-      "ep_total": -2.37,
-      "std_dev": 7.38,
+      "ep_race": 0.42,
+      "ep_sprint": -0.63,
+      "ep_total": -0.21,
+      "std_dev": 4.73,
       "p_win": 0.0013,
       "p_podium": 0.0108,
       "p_top6": 0.0728,
@@ -812,10 +815,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -0.78,
-      "ep_sprint": -1.73,
-      "ep_total": -2.5,
-      "std_dev": 7.22,
+      "ep_race": 0.29,
+      "ep_sprint": -0.67,
+      "ep_total": -0.38,
+      "std_dev": 4.56,
       "p_win": 0.0012,
       "p_podium": 0.0086,
       "p_top6": 0.0631,
@@ -855,10 +858,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -0.97,
-      "ep_sprint": -1.77,
-      "ep_total": -2.74,
-      "std_dev": 7.02,
+      "ep_race": 0.08,
+      "ep_sprint": -0.72,
+      "ep_total": -0.64,
+      "std_dev": 4.34,
       "p_win": 0.0008,
       "p_podium": 0.0069,
       "p_top6": 0.0506,
@@ -898,10 +901,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -1.14,
-      "ep_sprint": -1.86,
-      "ep_total": -3.0,
-      "std_dev": 6.99,
+      "ep_race": -0.07,
+      "ep_sprint": -0.79,
+      "ep_total": -0.85,
+      "std_dev": 4.24,
       "p_win": 0.0008,
       "p_podium": 0.0054,
       "p_top6": 0.044,
@@ -941,10 +944,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -1.37,
-      "ep_sprint": -1.92,
-      "ep_total": -3.29,
-      "std_dev": 6.78,
+      "ep_race": -0.31,
+      "ep_sprint": -0.86,
+      "ep_total": -1.17,
+      "std_dev": 3.99,
       "p_win": 0.0006,
       "p_podium": 0.0041,
       "p_top6": 0.0304,
@@ -984,10 +987,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -1.95,
-      "ep_sprint": -2.07,
-      "ep_total": -4.02,
-      "std_dev": 6.26,
+      "ep_race": -0.89,
+      "ep_sprint": -1.02,
+      "ep_total": -1.91,
+      "std_dev": 3.26,
       "p_win": 0.0001,
       "p_podium": 0.0005,
       "p_top6": 0.0049,
@@ -1020,49 +1023,6 @@
       ]
     },
     {
-      "name": "Sergio P\u00e9rez",
-      "abbr": "PER",
-      "team_idx": 9,
-      "lambda": -3.638444313544504,
-      "sigma_drv": 1.0,
-      "chaos_alpha": null,
-      "p_dnf": 0.1,
-      "ep_race": -1.99,
-      "ep_sprint": -2.06,
-      "ep_total": -4.05,
-      "std_dev": 6.17,
-      "p_win": 0.0,
-      "p_podium": 0.0003,
-      "p_top6": 0.0027,
-      "p_top10": 0.0322,
-      "p_no_points": 0.8639,
-      "position_distribution": [
-        0.0,
-        8e-05,
-        0.00018,
-        0.00036,
-        0.0007,
-        0.00138,
-        0.00244,
-        0.00472,
-        0.00806,
-        0.01428,
-        0.02494,
-        0.03948,
-        0.05796,
-        0.07944,
-        0.09798,
-        0.11742,
-        0.12222,
-        0.1163,
-        0.09682,
-        0.06462,
-        0.03566,
-        0.01106,
-        0.1039
-      ]
-    },
-    {
       "name": "Lance Stroll",
       "abbr": "STR",
       "team_idx": 10,
@@ -1070,10 +1030,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -1.97,
-      "ep_sprint": -2.1,
-      "ep_total": -4.07,
-      "std_dev": 6.32,
+      "ep_race": -0.89,
+      "ep_sprint": -1.03,
+      "ep_total": -1.93,
+      "std_dev": 3.31,
       "p_win": 0.0001,
       "p_podium": 0.0007,
       "p_top6": 0.0053,
@@ -1106,6 +1066,49 @@
       ]
     },
     {
+      "name": "Sergio P\u00e9rez",
+      "abbr": "PER",
+      "team_idx": 9,
+      "lambda": -3.638444313544504,
+      "sigma_drv": 1.0,
+      "chaos_alpha": null,
+      "p_dnf": 0.1,
+      "ep_race": -0.95,
+      "ep_sprint": -1.02,
+      "ep_total": -1.97,
+      "std_dev": 3.16,
+      "p_win": 0.0,
+      "p_podium": 0.0003,
+      "p_top6": 0.0027,
+      "p_top10": 0.0322,
+      "p_no_points": 0.8639,
+      "position_distribution": [
+        0.0,
+        8e-05,
+        0.00018,
+        0.00036,
+        0.0007,
+        0.00138,
+        0.00244,
+        0.00472,
+        0.00806,
+        0.01428,
+        0.02494,
+        0.03948,
+        0.05796,
+        0.07944,
+        0.09798,
+        0.11742,
+        0.12222,
+        0.1163,
+        0.09682,
+        0.06462,
+        0.03566,
+        0.01106,
+        0.1039
+      ]
+    },
+    {
       "name": "Valtteri Bottas",
       "abbr": "BOT",
       "team_idx": 9,
@@ -1113,10 +1116,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -2.03,
-      "ep_sprint": -2.13,
-      "ep_total": -4.16,
-      "std_dev": 6.31,
+      "ep_race": -0.95,
+      "ep_sprint": -1.05,
+      "ep_total": -2.0,
+      "std_dev": 3.26,
       "p_win": 0.0001,
       "p_podium": 0.0004,
       "p_top6": 0.0042,
@@ -1158,7 +1161,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1166,7 +1169,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1174,7 +1177,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1182,7 +1185,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.111
         },
         {
@@ -1190,14 +1193,14 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 0.912
         }
       ],
-      "ep_base_total": 55.3,
+      "ep_base_total": 65.82,
       "ep_bonus_total": 8.542,
-      "ep_grand_total": 63.84,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 74.36,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 2,
@@ -1207,7 +1210,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1215,7 +1218,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1223,7 +1226,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1231,7 +1234,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.111
         },
         {
@@ -1239,14 +1242,14 @@
           "name": "Lewis Hamilton",
           "abbr": "HAM",
           "team_idx": 2,
-          "ep_base": 6.24,
+          "ep_base": 8.42,
           "slot_bonus_ev": 0.982
         }
       ],
-      "ep_base_total": 53.54,
+      "ep_base_total": 64.14,
       "ep_bonus_total": 8.612,
-      "ep_grand_total": 62.15,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 72.75,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 3,
@@ -1256,7 +1259,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1264,7 +1267,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1272,7 +1275,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1280,7 +1283,7 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 1.102
         },
         {
@@ -1288,14 +1291,14 @@
           "name": "Lewis Hamilton",
           "abbr": "HAM",
           "team_idx": 2,
-          "ep_base": 6.24,
+          "ep_base": 8.42,
           "slot_bonus_ev": 0.982
         }
       ],
-      "ep_base_total": 52.8,
+      "ep_base_total": 63.4,
       "ep_bonus_total": 8.604,
-      "ep_grand_total": 61.4,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 72.0,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 4,
@@ -1305,7 +1308,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1313,7 +1316,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1321,7 +1324,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.263
         },
         {
@@ -1329,7 +1332,7 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 1.102
         },
         {
@@ -1337,14 +1340,14 @@
           "name": "Lewis Hamilton",
           "abbr": "HAM",
           "team_idx": 2,
-          "ep_base": 6.24,
+          "ep_base": 8.42,
           "slot_bonus_ev": 0.982
         }
       ],
-      "ep_base_total": 51.96,
+      "ep_base_total": 62.53,
       "ep_bonus_total": 8.547,
-      "ep_grand_total": 60.51,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 71.08,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 5,
@@ -1354,7 +1357,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1362,7 +1365,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1370,7 +1373,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1378,7 +1381,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.111
         },
         {
@@ -1386,14 +1389,14 @@
           "name": "Max Verstappen",
           "abbr": "VER",
           "team_idx": 4,
-          "ep_base": 4.48,
+          "ep_base": 6.63,
           "slot_bonus_ev": 0.944
         }
       ],
-      "ep_base_total": 51.78,
+      "ep_base_total": 62.35,
       "ep_bonus_total": 8.574,
-      "ep_grand_total": 60.35,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 70.92,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 6,
@@ -1403,7 +1406,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1411,7 +1414,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1419,7 +1422,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1427,7 +1430,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.111
         },
         {
@@ -1435,14 +1438,14 @@
           "name": "Isack Hadjar",
           "abbr": "HAD",
           "team_idx": 4,
-          "ep_base": 3.93,
+          "ep_base": 6.05,
           "slot_bonus_ev": 0.938
         }
       ],
-      "ep_base_total": 51.23,
+      "ep_base_total": 61.77,
       "ep_bonus_total": 8.568,
-      "ep_grand_total": 59.8,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 70.34,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 7,
@@ -1452,7 +1455,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1460,7 +1463,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1468,7 +1471,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1476,7 +1479,7 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 1.102
         },
         {
@@ -1484,14 +1487,14 @@
           "name": "Max Verstappen",
           "abbr": "VER",
           "team_idx": 4,
-          "ep_base": 4.48,
+          "ep_base": 6.63,
           "slot_bonus_ev": 0.944
         }
       ],
-      "ep_base_total": 51.04,
+      "ep_base_total": 61.61,
       "ep_bonus_total": 8.565,
-      "ep_grand_total": 59.61,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 70.18,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 8,
@@ -1501,7 +1504,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1509,7 +1512,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1517,7 +1520,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1525,7 +1528,7 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 1.102
         },
         {
@@ -1533,14 +1536,14 @@
           "name": "Isack Hadjar",
           "abbr": "HAD",
           "team_idx": 4,
-          "ep_base": 3.93,
+          "ep_base": 6.05,
           "slot_bonus_ev": 0.938
         }
       ],
-      "ep_base_total": 50.49,
+      "ep_base_total": 61.03,
       "ep_bonus_total": 8.56,
-      "ep_grand_total": 59.05,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 69.59,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 9,
@@ -1550,7 +1553,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1558,7 +1561,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1566,7 +1569,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.263
         },
         {
@@ -1574,7 +1577,7 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 1.102
         },
         {
@@ -1582,14 +1585,14 @@
           "name": "Max Verstappen",
           "abbr": "VER",
           "team_idx": 4,
-          "ep_base": 4.48,
+          "ep_base": 6.63,
           "slot_bonus_ev": 0.944
         }
       ],
-      "ep_base_total": 50.2,
+      "ep_base_total": 60.74,
       "ep_bonus_total": 8.508,
-      "ep_grand_total": 58.71,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 69.25,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 10,
@@ -1599,7 +1602,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1607,7 +1610,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1615,7 +1618,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1623,7 +1626,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.111
         },
         {
@@ -1631,14 +1634,14 @@
           "name": "Pierre Gasly",
           "abbr": "GAS",
           "team_idx": 3,
-          "ep_base": 2.52,
+          "ep_base": 4.67,
           "slot_bonus_ev": 0.804
         }
       ],
-      "ep_base_total": 49.82,
+      "ep_base_total": 60.39,
       "ep_bonus_total": 8.433,
-      "ep_grand_total": 58.25,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 68.82,
+      "exact_pos_bonus": 10
     }
   ],
   "fit": {

--- a/public/data/odds_input/miami-gp-2026.json
+++ b/public/data/odds_input/miami-gp-2026.json
@@ -2,7 +2,8 @@
   "race": "Miami Grand Prix",
   "date": "2026-05-03",
   "is_sprint": true,
-  "markets": {
+  "_comment": "Dual-event manual odds. Race + Sprint are fit separately and produce three optimal-lineup sets (combined / race-only / sprint-only). Sprint odds below are illustrative — replace with current Oddschecker sprint lines before relying on output.",
+  "markets_race": {
     "win": {
       "Russell": -120, "Norris": 180, "Leclerc": 400,
       "Antonelli": 450, "Hamilton": 600, "Piastri": 700,
@@ -42,6 +43,38 @@
       "Ocon": 700, "Colapinto": 500, "Stroll": 400,
       "Hulkenberg": 350, "Bortoleto": 350,
       "Perez": 300, "Bottas": 300
+    }
+  },
+  "markets_sprint": {
+    "win": {
+      "Antonelli": 165, "Russell": 250, "Leclerc": 500,
+      "Piastri": 700, "Norris": 350, "Hamilton": 800,
+      "Verstappen": 1100, "Lawson": 3500, "Albon": 5000,
+      "Sainz": 5000, "Bearman": 6000, "Gasly": 6000,
+      "Tsunoda": 9000, "Alonso": 9000, "Hadjar": 12000,
+      "Ocon": 15000, "Colapinto": 18000, "Stroll": 22000,
+      "Hulkenberg": 28000, "Bortoleto": 40000,
+      "Perez": 45000, "Bottas": 55000
+    },
+    "podium": {
+      "Antonelli": -200, "Russell": -130, "Leclerc": 130,
+      "Piastri": 200, "Norris": -120, "Hamilton": 180,
+      "Verstappen": 250, "Lawson": 700, "Albon": 900,
+      "Sainz": 1000, "Bearman": 1300, "Gasly": 1600,
+      "Tsunoda": 2200, "Alonso": 2200, "Hadjar": 2700,
+      "Ocon": 3800, "Colapinto": 4800, "Stroll": 6000,
+      "Hulkenberg": 7500, "Bortoleto": 9500,
+      "Perez": 13000, "Bottas": 19000
+    },
+    "dnf": {
+      "Russell": 1400, "Norris": 1100, "Leclerc": 1000,
+      "Antonelli": 900, "Hamilton": 1100, "Piastri": 1000,
+      "Verstappen": 600, "Lawson": 600, "Albon": 700,
+      "Sainz": 700, "Bearman": 800, "Gasly": 800,
+      "Tsunoda": 800, "Alonso": 500, "Hadjar": 700,
+      "Ocon": 800, "Colapinto": 600, "Stroll": 500,
+      "Hulkenberg": 450, "Bortoleto": 450,
+      "Perez": 400, "Bottas": 400
     }
   }
 }

--- a/public/data/races/japanese-gp.json
+++ b/public/data/races/japanese-gp.json
@@ -9,7 +9,9 @@
     "devig_method": "shin",
     "fit_loss": 0.2788882570386641,
     "fit_converged": true,
-    "run_type": ""
+    "run_type": "",
+    "backfilled_at": "2026-05-02T18:44:13.796363+00:00",
+    "backfill_note": "DNF penalty corrected from -10 to -10; per-driver EPs and lineups recomputed from existing position_distribution arrays."
   },
   "teams": [
     {
@@ -80,7 +82,8 @@
       "7": 2,
       "8": 1
     },
-    "dnf_penalty": -10
+    "dnf_penalty": -10,
+    "exact_bonus": 10
   },
   "drivers": [
     {
@@ -1034,7 +1037,7 @@
       "ep_base_total": 45.1,
       "ep_bonus_total": 6.477,
       "ep_grand_total": 51.58,
-      "exact_pos_bonus": 10.0
+      "exact_pos_bonus": 10
     },
     {
       "rank": 2,
@@ -1083,7 +1086,7 @@
       "ep_base_total": 45.09,
       "ep_bonus_total": 6.424,
       "ep_grand_total": 51.51,
-      "exact_pos_bonus": 10.0
+      "exact_pos_bonus": 10
     },
     {
       "rank": 3,
@@ -1132,7 +1135,7 @@
       "ep_base_total": 44.29,
       "ep_bonus_total": 6.349,
       "ep_grand_total": 50.64,
-      "exact_pos_bonus": 10.0
+      "exact_pos_bonus": 10
     },
     {
       "rank": 4,
@@ -1181,7 +1184,7 @@
       "ep_base_total": 44.1,
       "ep_bonus_total": 6.357,
       "ep_grand_total": 50.46,
-      "exact_pos_bonus": 10.0
+      "exact_pos_bonus": 10
     },
     {
       "rank": 5,
@@ -1230,7 +1233,7 @@
       "ep_base_total": 43.8,
       "ep_bonus_total": 6.336,
       "ep_grand_total": 50.14,
-      "exact_pos_bonus": 10.0
+      "exact_pos_bonus": 10
     },
     {
       "rank": 6,
@@ -1279,7 +1282,7 @@
       "ep_base_total": 43.35,
       "ep_bonus_total": 6.275,
       "ep_grand_total": 49.62,
-      "exact_pos_bonus": 10.0
+      "exact_pos_bonus": 10
     },
     {
       "rank": 7,
@@ -1328,7 +1331,7 @@
       "ep_base_total": 42.79,
       "ep_bonus_total": 6.253,
       "ep_grand_total": 49.04,
-      "exact_pos_bonus": 10.0
+      "exact_pos_bonus": 10
     },
     {
       "rank": 8,
@@ -1377,7 +1380,7 @@
       "ep_base_total": 42.74,
       "ep_bonus_total": 6.218,
       "ep_grand_total": 48.96,
-      "exact_pos_bonus": 10.0
+      "exact_pos_bonus": 10
     },
     {
       "rank": 9,
@@ -1426,7 +1429,7 @@
       "ep_base_total": 42.48,
       "ep_bonus_total": 6.184,
       "ep_grand_total": 48.66,
-      "exact_pos_bonus": 10.0
+      "exact_pos_bonus": 10
     },
     {
       "rank": 10,
@@ -1475,7 +1478,7 @@
       "ep_base_total": 41.99,
       "ep_bonus_total": 6.177,
       "ep_grand_total": 48.17,
-      "exact_pos_bonus": 10.0
+      "exact_pos_bonus": 10
     }
   ],
   "fit": {

--- a/public/data/races/miami-gp.json
+++ b/public/data/races/miami-gp.json
@@ -117,7 +117,9 @@
         "Sergio Perez": 10000.0,
         "Valtteri Bottas": 10000.0
       }
-    }
+    },
+    "backfilled_at": "2026-05-02T18:44:13.838577+00:00",
+    "backfill_note": "DNF penalty corrected from -20 to -10; per-driver EPs and lineups recomputed from existing position_distribution arrays."
   },
   "teams": [
     {
@@ -199,7 +201,8 @@
       "7": 2,
       "8": 1
     },
-    "dnf_penalty": -20
+    "dnf_penalty": -10,
+    "exact_bonus": 10
   },
   "drivers": [
     {
@@ -210,10 +213,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 12.16,
-      "ep_sprint": 2.88,
-      "ep_total": 15.04,
-      "std_dev": 13.83,
+      "ep_race": 13.21,
+      "ep_sprint": 3.93,
+      "ep_total": 17.15,
+      "std_dev": 11.52,
       "p_win": 0.3254,
       "p_podium": 0.5955,
       "p_top6": 0.7207,
@@ -253,10 +256,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 11.27,
-      "ep_sprint": 2.67,
-      "ep_total": 13.94,
-      "std_dev": 13.39,
+      "ep_race": 12.31,
+      "ep_sprint": 3.71,
+      "ep_total": 16.02,
+      "std_dev": 11.12,
       "p_win": 0.2545,
       "p_podium": 0.5576,
       "p_top6": 0.7072,
@@ -296,10 +299,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 7.97,
-      "ep_sprint": 1.61,
-      "ep_total": 9.58,
-      "std_dev": 12.18,
+      "ep_race": 9.03,
+      "ep_sprint": 2.68,
+      "ep_total": 11.71,
+      "std_dev": 9.92,
       "p_win": 0.1072,
       "p_podium": 0.3726,
       "p_top6": 0.6187,
@@ -339,10 +342,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 7.33,
-      "ep_sprint": 1.4,
-      "ep_total": 8.74,
-      "std_dev": 11.86,
+      "ep_race": 8.39,
+      "ep_sprint": 2.46,
+      "ep_total": 10.84,
+      "std_dev": 9.62,
       "p_win": 0.0881,
       "p_podium": 0.3299,
       "p_top6": 0.5935,
@@ -382,10 +385,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 6.79,
-      "ep_sprint": 1.21,
-      "ep_total": 8.0,
-      "std_dev": 11.6,
+      "ep_race": 7.84,
+      "ep_sprint": 2.26,
+      "ep_total": 10.1,
+      "std_dev": 9.36,
       "p_win": 0.0727,
       "p_podium": 0.2964,
       "p_top6": 0.5688,
@@ -425,10 +428,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 5.54,
-      "ep_sprint": 0.7,
-      "ep_total": 6.24,
-      "std_dev": 11.16,
+      "ep_race": 6.63,
+      "ep_sprint": 1.79,
+      "ep_total": 8.42,
+      "std_dev": 8.86,
       "p_win": 0.0486,
       "p_podium": 0.2259,
       "p_top6": 0.5108,
@@ -468,10 +471,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 4.27,
-      "ep_sprint": 0.22,
-      "ep_total": 4.48,
-      "std_dev": 10.42,
+      "ep_race": 5.34,
+      "ep_sprint": 1.29,
+      "ep_total": 6.63,
+      "std_dev": 8.13,
       "p_win": 0.0296,
       "p_podium": 0.1541,
       "p_top6": 0.4311,
@@ -511,10 +514,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 3.86,
-      "ep_sprint": 0.07,
-      "ep_total": 3.93,
-      "std_dev": 10.14,
+      "ep_race": 4.92,
+      "ep_sprint": 1.13,
+      "ep_total": 6.05,
+      "std_dev": 7.84,
       "p_win": 0.0231,
       "p_podium": 0.1324,
       "p_top6": 0.4036,
@@ -554,10 +557,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 2.86,
-      "ep_sprint": -0.35,
-      "ep_total": 2.52,
-      "std_dev": 9.67,
+      "ep_race": 3.94,
+      "ep_sprint": 0.73,
+      "ep_total": 4.67,
+      "std_dev": 7.34,
       "p_win": 0.0156,
       "p_podium": 0.0946,
       "p_top6": 0.3304,
@@ -597,10 +600,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 2.69,
-      "ep_sprint": -0.4,
-      "ep_total": 2.29,
-      "std_dev": 9.49,
+      "ep_race": 3.75,
+      "ep_sprint": 0.66,
+      "ep_total": 4.41,
+      "std_dev": 7.18,
       "p_win": 0.0134,
       "p_podium": 0.0869,
       "p_top6": 0.3159,
@@ -640,10 +643,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 2.61,
-      "ep_sprint": -0.42,
-      "ep_total": 2.19,
-      "std_dev": 9.4,
+      "ep_race": 3.66,
+      "ep_sprint": 0.63,
+      "ep_total": 4.29,
+      "std_dev": 7.09,
       "p_win": 0.0124,
       "p_podium": 0.0819,
       "p_top6": 0.309,
@@ -683,10 +686,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": 0.01,
-      "ep_sprint": -1.44,
-      "ep_total": -1.43,
-      "std_dev": 7.78,
+      "ep_race": 1.07,
+      "ep_sprint": -0.38,
+      "ep_total": 0.69,
+      "std_dev": 5.26,
       "p_win": 0.0024,
       "p_podium": 0.019,
       "p_top6": 0.1137,
@@ -726,10 +729,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -0.25,
-      "ep_sprint": -1.55,
-      "ep_total": -1.8,
-      "std_dev": 7.65,
+      "ep_race": 0.82,
+      "ep_sprint": -0.48,
+      "ep_total": 0.34,
+      "std_dev": 5.08,
       "p_win": 0.002,
       "p_podium": 0.0156,
       "p_top6": 0.0985,
@@ -769,10 +772,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -0.66,
-      "ep_sprint": -1.71,
-      "ep_total": -2.37,
-      "std_dev": 7.38,
+      "ep_race": 0.42,
+      "ep_sprint": -0.63,
+      "ep_total": -0.21,
+      "std_dev": 4.73,
       "p_win": 0.0013,
       "p_podium": 0.0108,
       "p_top6": 0.0728,
@@ -812,10 +815,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -0.78,
-      "ep_sprint": -1.73,
-      "ep_total": -2.5,
-      "std_dev": 7.22,
+      "ep_race": 0.29,
+      "ep_sprint": -0.67,
+      "ep_total": -0.38,
+      "std_dev": 4.56,
       "p_win": 0.0012,
       "p_podium": 0.0086,
       "p_top6": 0.0631,
@@ -855,10 +858,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -0.97,
-      "ep_sprint": -1.77,
-      "ep_total": -2.74,
-      "std_dev": 7.02,
+      "ep_race": 0.08,
+      "ep_sprint": -0.72,
+      "ep_total": -0.64,
+      "std_dev": 4.34,
       "p_win": 0.0008,
       "p_podium": 0.0069,
       "p_top6": 0.0506,
@@ -898,10 +901,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -1.14,
-      "ep_sprint": -1.86,
-      "ep_total": -3.0,
-      "std_dev": 6.99,
+      "ep_race": -0.07,
+      "ep_sprint": -0.79,
+      "ep_total": -0.85,
+      "std_dev": 4.24,
       "p_win": 0.0008,
       "p_podium": 0.0054,
       "p_top6": 0.044,
@@ -941,10 +944,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -1.37,
-      "ep_sprint": -1.92,
-      "ep_total": -3.29,
-      "std_dev": 6.78,
+      "ep_race": -0.31,
+      "ep_sprint": -0.86,
+      "ep_total": -1.17,
+      "std_dev": 3.99,
       "p_win": 0.0006,
       "p_podium": 0.0041,
       "p_top6": 0.0304,
@@ -984,10 +987,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -1.95,
-      "ep_sprint": -2.07,
-      "ep_total": -4.02,
-      "std_dev": 6.26,
+      "ep_race": -0.89,
+      "ep_sprint": -1.02,
+      "ep_total": -1.91,
+      "std_dev": 3.26,
       "p_win": 0.0001,
       "p_podium": 0.0005,
       "p_top6": 0.0049,
@@ -1020,49 +1023,6 @@
       ]
     },
     {
-      "name": "Sergio P\u00e9rez",
-      "abbr": "PER",
-      "team_idx": 9,
-      "lambda": -3.638444313544504,
-      "sigma_drv": 1.0,
-      "chaos_alpha": null,
-      "p_dnf": 0.1,
-      "ep_race": -1.99,
-      "ep_sprint": -2.06,
-      "ep_total": -4.05,
-      "std_dev": 6.17,
-      "p_win": 0.0,
-      "p_podium": 0.0003,
-      "p_top6": 0.0027,
-      "p_top10": 0.0322,
-      "p_no_points": 0.8639,
-      "position_distribution": [
-        0.0,
-        8e-05,
-        0.00018,
-        0.00036,
-        0.0007,
-        0.00138,
-        0.00244,
-        0.00472,
-        0.00806,
-        0.01428,
-        0.02494,
-        0.03948,
-        0.05796,
-        0.07944,
-        0.09798,
-        0.11742,
-        0.12222,
-        0.1163,
-        0.09682,
-        0.06462,
-        0.03566,
-        0.01106,
-        0.1039
-      ]
-    },
-    {
       "name": "Lance Stroll",
       "abbr": "STR",
       "team_idx": 10,
@@ -1070,10 +1030,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -1.97,
-      "ep_sprint": -2.1,
-      "ep_total": -4.07,
-      "std_dev": 6.32,
+      "ep_race": -0.89,
+      "ep_sprint": -1.03,
+      "ep_total": -1.93,
+      "std_dev": 3.31,
       "p_win": 0.0001,
       "p_podium": 0.0007,
       "p_top6": 0.0053,
@@ -1106,6 +1066,49 @@
       ]
     },
     {
+      "name": "Sergio P\u00e9rez",
+      "abbr": "PER",
+      "team_idx": 9,
+      "lambda": -3.638444313544504,
+      "sigma_drv": 1.0,
+      "chaos_alpha": null,
+      "p_dnf": 0.1,
+      "ep_race": -0.95,
+      "ep_sprint": -1.02,
+      "ep_total": -1.97,
+      "std_dev": 3.16,
+      "p_win": 0.0,
+      "p_podium": 0.0003,
+      "p_top6": 0.0027,
+      "p_top10": 0.0322,
+      "p_no_points": 0.8639,
+      "position_distribution": [
+        0.0,
+        8e-05,
+        0.00018,
+        0.00036,
+        0.0007,
+        0.00138,
+        0.00244,
+        0.00472,
+        0.00806,
+        0.01428,
+        0.02494,
+        0.03948,
+        0.05796,
+        0.07944,
+        0.09798,
+        0.11742,
+        0.12222,
+        0.1163,
+        0.09682,
+        0.06462,
+        0.03566,
+        0.01106,
+        0.1039
+      ]
+    },
+    {
       "name": "Valtteri Bottas",
       "abbr": "BOT",
       "team_idx": 9,
@@ -1113,10 +1116,10 @@
       "sigma_drv": 1.0,
       "chaos_alpha": null,
       "p_dnf": 0.1,
-      "ep_race": -2.03,
-      "ep_sprint": -2.13,
-      "ep_total": -4.16,
-      "std_dev": 6.31,
+      "ep_race": -0.95,
+      "ep_sprint": -1.05,
+      "ep_total": -2.0,
+      "std_dev": 3.26,
       "p_win": 0.0001,
       "p_podium": 0.0004,
       "p_top6": 0.0042,
@@ -1158,7 +1161,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1166,7 +1169,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1174,7 +1177,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1182,7 +1185,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.111
         },
         {
@@ -1190,14 +1193,14 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 0.912
         }
       ],
-      "ep_base_total": 55.3,
+      "ep_base_total": 65.82,
       "ep_bonus_total": 8.542,
-      "ep_grand_total": 63.84,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 74.36,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 2,
@@ -1207,7 +1210,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1215,7 +1218,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1223,7 +1226,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1231,7 +1234,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.111
         },
         {
@@ -1239,14 +1242,14 @@
           "name": "Lewis Hamilton",
           "abbr": "HAM",
           "team_idx": 2,
-          "ep_base": 6.24,
+          "ep_base": 8.42,
           "slot_bonus_ev": 0.982
         }
       ],
-      "ep_base_total": 53.54,
+      "ep_base_total": 64.14,
       "ep_bonus_total": 8.612,
-      "ep_grand_total": 62.15,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 72.75,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 3,
@@ -1256,7 +1259,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1264,7 +1267,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1272,7 +1275,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1280,7 +1283,7 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 1.102
         },
         {
@@ -1288,14 +1291,14 @@
           "name": "Lewis Hamilton",
           "abbr": "HAM",
           "team_idx": 2,
-          "ep_base": 6.24,
+          "ep_base": 8.42,
           "slot_bonus_ev": 0.982
         }
       ],
-      "ep_base_total": 52.8,
+      "ep_base_total": 63.4,
       "ep_bonus_total": 8.604,
-      "ep_grand_total": 61.4,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 72.0,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 4,
@@ -1305,7 +1308,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1313,7 +1316,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1321,7 +1324,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.263
         },
         {
@@ -1329,7 +1332,7 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 1.102
         },
         {
@@ -1337,14 +1340,14 @@
           "name": "Lewis Hamilton",
           "abbr": "HAM",
           "team_idx": 2,
-          "ep_base": 6.24,
+          "ep_base": 8.42,
           "slot_bonus_ev": 0.982
         }
       ],
-      "ep_base_total": 51.96,
+      "ep_base_total": 62.53,
       "ep_bonus_total": 8.547,
-      "ep_grand_total": 60.51,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 71.08,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 5,
@@ -1354,7 +1357,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1362,7 +1365,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1370,7 +1373,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1378,7 +1381,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.111
         },
         {
@@ -1386,14 +1389,14 @@
           "name": "Max Verstappen",
           "abbr": "VER",
           "team_idx": 4,
-          "ep_base": 4.48,
+          "ep_base": 6.63,
           "slot_bonus_ev": 0.944
         }
       ],
-      "ep_base_total": 51.78,
+      "ep_base_total": 62.35,
       "ep_bonus_total": 8.574,
-      "ep_grand_total": 60.35,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 70.92,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 6,
@@ -1403,7 +1406,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1411,7 +1414,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1419,7 +1422,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1427,7 +1430,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.111
         },
         {
@@ -1435,14 +1438,14 @@
           "name": "Isack Hadjar",
           "abbr": "HAD",
           "team_idx": 4,
-          "ep_base": 3.93,
+          "ep_base": 6.05,
           "slot_bonus_ev": 0.938
         }
       ],
-      "ep_base_total": 51.23,
+      "ep_base_total": 61.77,
       "ep_bonus_total": 8.568,
-      "ep_grand_total": 59.8,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 70.34,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 7,
@@ -1452,7 +1455,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1460,7 +1463,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1468,7 +1471,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1476,7 +1479,7 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 1.102
         },
         {
@@ -1484,14 +1487,14 @@
           "name": "Max Verstappen",
           "abbr": "VER",
           "team_idx": 4,
-          "ep_base": 4.48,
+          "ep_base": 6.63,
           "slot_bonus_ev": 0.944
         }
       ],
-      "ep_base_total": 51.04,
+      "ep_base_total": 61.61,
       "ep_bonus_total": 8.565,
-      "ep_grand_total": 59.61,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 70.18,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 8,
@@ -1501,7 +1504,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1509,7 +1512,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1517,7 +1520,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1525,7 +1528,7 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 1.102
         },
         {
@@ -1533,14 +1536,14 @@
           "name": "Isack Hadjar",
           "abbr": "HAD",
           "team_idx": 4,
-          "ep_base": 3.93,
+          "ep_base": 6.05,
           "slot_bonus_ev": 0.938
         }
       ],
-      "ep_base_total": 50.49,
+      "ep_base_total": 61.03,
       "ep_bonus_total": 8.56,
-      "ep_grand_total": 59.05,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 69.59,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 9,
@@ -1550,7 +1553,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1558,7 +1561,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1566,7 +1569,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.263
         },
         {
@@ -1574,7 +1577,7 @@
           "name": "Lando Norris",
           "abbr": "NOR",
           "team_idx": 1,
-          "ep_base": 8.0,
+          "ep_base": 10.1,
           "slot_bonus_ev": 1.102
         },
         {
@@ -1582,14 +1585,14 @@
           "name": "Max Verstappen",
           "abbr": "VER",
           "team_idx": 4,
-          "ep_base": 4.48,
+          "ep_base": 6.63,
           "slot_bonus_ev": 0.944
         }
       ],
-      "ep_base_total": 50.2,
+      "ep_base_total": 60.74,
       "ep_bonus_total": 8.508,
-      "ep_grand_total": 58.71,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 69.25,
+      "exact_pos_bonus": 10
     },
     {
       "rank": 10,
@@ -1599,7 +1602,7 @@
           "name": "Andrea Kimi Antonelli",
           "abbr": "ANT",
           "team_idx": 0,
-          "ep_base": 15.04,
+          "ep_base": 17.15,
           "slot_bonus_ev": 3.254
         },
         {
@@ -1607,7 +1610,7 @@
           "name": "George Russell",
           "abbr": "RUS",
           "team_idx": 0,
-          "ep_base": 13.94,
+          "ep_base": 16.02,
           "slot_bonus_ev": 1.944
         },
         {
@@ -1615,7 +1618,7 @@
           "name": "Charles Leclerc",
           "abbr": "LEC",
           "team_idx": 2,
-          "ep_base": 9.58,
+          "ep_base": 11.71,
           "slot_bonus_ev": 1.32
         },
         {
@@ -1623,7 +1626,7 @@
           "name": "Oscar Piastri",
           "abbr": "PIA",
           "team_idx": 1,
-          "ep_base": 8.74,
+          "ep_base": 10.84,
           "slot_bonus_ev": 1.111
         },
         {
@@ -1631,14 +1634,14 @@
           "name": "Pierre Gasly",
           "abbr": "GAS",
           "team_idx": 3,
-          "ep_base": 2.52,
+          "ep_base": 4.67,
           "slot_bonus_ev": 0.804
         }
       ],
-      "ep_base_total": 49.82,
+      "ep_base_total": 60.39,
       "ep_bonus_total": 8.433,
-      "ep_grand_total": 58.25,
-      "exact_pos_bonus": 10.0
+      "ep_grand_total": 68.82,
+      "exact_pos_bonus": 10
     }
   ],
   "fit": {

--- a/site/src/components/OptimalLineup.jsx
+++ b/site/src/components/OptimalLineup.jsx
@@ -6,21 +6,25 @@ import { useState } from 'react';
  * Shows a compact summary table of the top N lineups (one row each),
  * then a full per-driver breakdown for whichever lineup is selected.
  */
-export default function OptimalLineup({ lineups, teams }) {
+export default function OptimalLineup({ lineups, teams, title, subtitle }) {
   const [selectedRank, setSelectedRank] = useState(1);
   if (!lineups?.length) return null;
 
   const selected = lineups.find(l => l.rank === selectedRank) ?? lineups[0];
+  const resolvedTitle = title ?? `Top ${lineups.length} Lineups`;
+  const defaultSubtitle = (
+    <>
+      Ordered by expected points including the +{lineups[0].exact_pos_bonus} exact-position
+      bonus (earned when a driver finishes in the same slot as their pick number).
+      Click a row to see the full breakdown.
+    </>
+  );
 
   return (
     <div className="optimal-lineup">
       <div className="lineup-header">
-        <h3 className="lineup-title">Top {lineups.length} Lineups</h3>
-        <p className="lineup-subtitle">
-          Ordered by expected points including the +{lineups[0].exact_pos_bonus} exact-position
-          bonus (earned when a driver finishes in the same slot as their pick number).
-          Click a row to see the full breakdown.
-        </p>
+        <h3 className="lineup-title">{resolvedTitle}</h3>
+        <p className="lineup-subtitle">{subtitle ?? defaultSubtitle}</p>
       </div>
 
       {/* Summary table — one row per lineup */}

--- a/site/src/pages/Dashboard.jsx
+++ b/site/src/pages/Dashboard.jsx
@@ -88,7 +88,34 @@ export default function Dashboard({ data }) {
       </div>
 
       {data.top_lineups?.length > 0 && (
-        <OptimalLineup lineups={data.top_lineups} teams={data.teams} />
+        <OptimalLineup
+          lineups={data.top_lineups}
+          teams={data.teams}
+          title={data.meta.is_sprint ? 'Top Lineups — Combined (Sprint + Race)' : 'Top Lineups'}
+          subtitle={
+            data.meta.is_sprint
+              ? `Same 5 picks scored across both events (sprint + race), including the +${data.scoring?.exact_bonus ?? 10} exact-position bonus per event. This is what you actually pick — the per-event sections below show what would be optimal if the league let you pick separately.`
+              : undefined
+          }
+        />
+      )}
+
+      {data.meta.is_sprint && data.top_lineups_race?.length > 0 && (
+        <OptimalLineup
+          lineups={data.top_lineups_race}
+          teams={data.teams}
+          title="Top Lineups — Grand Prix only"
+          subtitle="Hypothetical: optimal 5 picks if the lineup were scored against the Grand Prix only (sprint ignored)."
+        />
+      )}
+
+      {data.meta.is_sprint && data.top_lineups_sprint?.length > 0 && (
+        <OptimalLineup
+          lineups={data.top_lineups_sprint}
+          teams={data.teams}
+          title="Top Lineups — Sprint only"
+          subtitle="Hypothetical: optimal 5 picks if the lineup were scored against the sprint only (Grand Prix ignored). Useful for spotting drivers whose sprint odds diverge from race odds."
+        />
       )}
 
       <footer className="dash-footer">


### PR DESCRIPTION
## Summary

Sprint weekends now scrape and fit a separate Plackett-Luce model for the sprint event, alongside the race fit. The dashboard surfaces three optimal lineup tables on sprint weekends:

- **Combined** — the actually-actionable lineup (league rules require the same 5 picks for both events)
- **Grand Prix only** — hypothetical, if you could pick separately for the race
- **Sprint only** — hypothetical, useful for spotting drivers whose sprint vs. race odds diverge

Also: re-enabled DNF market scraping (Oddschecker brought back \"Not To Be Classified\"), and corrected scoring constants to match the league's `scorer.py`.

## Why

- Until now, sprint expected points were computed by reusing the race PL distribution scored under the sprint points table — but Oddschecker now publishes separate sprint markets, so the model can fit them properly. For Miami, Antonelli is the sprint favorite while Russell is the race favorite; the old model couldn't represent that divergence.
- The DNF penalty was wrong (`-20`) in `pipeline/config.py` and `CLAUDE.md`; the league's `scorer.py` uses `-10`. Every existing race output's expected points were therefore stale.
- The exact-position slot bonus was hardcoded as a `10.0` default arg in `find_top_lineups` rather than a documented config constant; it's now both, and the rule is written down in CLAUDE.md.

## What changed

### Pipeline
- **`odds_fetcher.py`** — added `dnf` to `MARKET_URL_CANDIDATES` (with multiple slug variants); for sprint weekends, scrape `<race-slug>-sprint/...` paths; return shape is now `{event: {market: {driver: odds}}}`; `process_odds_to_fair_probs` mirrors the new shape.
- **`update.py`** — fits race always, sprint when its own odds are present; produces three lineup arrays; adds `fit_sprint`, sprint-suffixed driver fields, `scoring.exact_bonus` to the JSON.
- **`plackett_luce.py`** — split `generate_full_output` into `simulate_event_metrics` + `assemble_driver_records` so race and sprint can be simulated independently from separate fits; `find_top_lineups` parameterized by `score_key` and `dist_keys`.
- **`config.py`** — `DNF_PENALTY = -10` (was -20); added `EXACT_BONUS = 10`.

### Manual odds template
- `miami-gp-2026.json` converted to dual `markets_race` / `markets_sprint` shape. The sprint odds in the file are illustrative — replace with real Oddschecker lines before relying on output. Legacy flat `markets` key still accepted as race-only.

### Backfill
- New `pipeline/backfill_dnf_penalty.py` recomputes `ep_race`/`ep_sprint`/`ep_total`/`std_dev` and re-runs `find_top_lineups` for per-race latest snapshots from their existing `position_distribution` arrays (no re-simulation needed). Already run against `latest.json` + `races/{japanese-gp,miami-gp}.json`.
- Timestamped historical snapshots under `races/<slug>/<ts>.json` are intentionally left frozen — they're \"what we predicted at the time\" artifacts.
- Idempotent: re-running on already-corrected files reports OK and no-ops.

### Frontend
- `Dashboard.jsx` renders the three `OptimalLineup` panels on sprint weekends with section labels; non-sprint weekends render exactly as before.
- `OptimalLineup` accepts `title` + `subtitle` props (backward-compat defaults preserved).

### Spec
- `CLAUDE.md` updated: DNF=-10, slot bonus rule documented, source-of-truth pointer to `scorer.py`.

## Test plan

- [x] `pytest pipeline/tests/` — 100/100 pass (includes new dual-event test in `test_odds_fetcher.py`)
- [x] `pipeline/update.py --manual public/data/odds_input/miami-gp-2026.json --no-scrape` — completes end-to-end; produces three distinct optimal lineup sets (Combined RUS-led; Sprint-only ANT-led — exactly the divergence the test odds modeled)
- [x] Frontend `npm run build` — clean
- [x] Backfill script dry-run + apply + idempotency check
- [ ] Frontend visual check on sprint weekend (Miami) once next pipeline run produces a real dual-fit JSON
- [ ] Live scrape verification against Oddschecker (deferred — only meaningful once we hit the next sprint weekend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)