### PR TITLE
Fix hourly Update workflow merge-conflict pileup with concurrency guard

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,6 +12,17 @@ on:
     # exactly one firing landing in each window.
     - cron: '0 * * * *'
 
+# A full run (scrape + PL fit + 50K sims) can take well over an hour, but
+# firings happen every hour. Without this, overlapping runs each build a PR
+# off a stale base and race to auto-merge it, and the loser's merge fails
+# with "Pull request has merge conflicts" (seen repeatedly in practice).
+# Queue instead of running concurrently — don't cancel an in-progress run,
+# since killing it mid-scrape/mid-fit wastes real work and can throw away a
+# run that was about to succeed.
+concurrency:
+  group: update-pipeline
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## What

Adds a `concurrency` guard to `.github/workflows/update.yml` so overlapping firings of the hourly Update workflow queue instead of racing each other.

## Why

Investigating this week's failed runs turned up three distinct issues; this PR fixes one of them.

Runs [#1221](https://github.com/rzeller/f1-xpts/actions/runs/32345544175) and [#1222](https://github.com/rzeller/f1-xpts/actions/runs/32350451944) (Aug 20) both scraped odds and fit the model successfully, but failed at the final auto-merge step:

```
GraphQL: Pull Request has merge conflicts (mergePullRequest)
```

Root cause: a full pipeline run (scrape + Plackett-Luce fit + 50K sims) can take well over an hour, but the workflow fires every hour (`cron: '0 * * * *'`) with no concurrency guard. When two runs overlap, each builds a PR against `bot/update-projections` from whatever master looked like at its own checkout, and both race to squash-merge — the loser hits a stale base and fails with the merge-conflict error above. It self-resolved once the backlog drained, but it will keep recurring any time two firings' active windows overlap (e.g. around session-boundary windows on a race weekend).

## Fix

```yaml
concurrency:
  group: update-pipeline
  cancel-in-progress: false
```

`cancel-in-progress: false` is deliberate: cancelling an in-flight run mid-scrape or mid-fit would waste real work and could throw away a run that was about to succeed. Runs now queue behind each other instead of racing to merge.

## Not in scope

Two other failures found during the investigation are tracked separately and not addressed here:
- Today's Oddschecker scrape returning zero markets for the Dutch GP across every URL candidate (no manual odds fallback checked in for this race yet).
- A one-off GitHub `codeload.github.com` 503/429 while downloading an action (Aug 17) — transient infra, not our code.


---
_Generated by [Claude Code](https://claude.ai/code/session_011ELTXmsRrBgUh7sbAmSJQn)_